### PR TITLE
いいねしたスポットの一覧機能(地図上に表示)

### DIFF
--- a/src/components/Layout/IndexLikedSpotLayout.jsx
+++ b/src/components/Layout/IndexLikedSpotLayout.jsx
@@ -1,0 +1,27 @@
+import { Box } from "@mui/material"
+import { MapView } from "../Map/MapView"
+import { SpotDetail } from "../../features/spots/components/SpotDetail";
+import { useNavigate, useParams } from "react-router-dom";
+import { LikedSpotIndex } from "../../features/spots/components/LikedSpotIndex";
+
+export const IndexLikedSpotLayout = () => {
+  const { spotId } = useParams();
+  const navigate = useNavigate();
+
+  const handleMarkerClick = (spotId) => {
+    navigate(`/spots/${spotId}`);
+  }
+
+  return (
+    <Box sx={{display: "flex", flexDirection: "row", height: "100%"}} >
+      <Box sx={{height: "100%", width :"75%"}} >
+        <MapView >
+          <LikedSpotIndex handleMarkerClick={handleMarkerClick} />
+        </MapView>
+      </Box>
+      <Box sx={{height: "100%", width :"25%"}}>
+        {spotId ? <SpotDetail spotId={spotId} /> : <div>Spotを選択してください</div>}
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/Layout/IndexLikedSpotLayout.jsx
+++ b/src/components/Layout/IndexLikedSpotLayout.jsx
@@ -1,8 +1,8 @@
 import { Box } from "@mui/material"
 import { MapView } from "../Map/MapView"
+import { LikedSpotIndex } from "../../features/spots/components/LikedSpotIndex";
 import { SpotDetail } from "../../features/spots/components/SpotDetail";
 import { useNavigate, useParams } from "react-router-dom";
-import { LikedSpotIndex } from "../../features/spots/components/LikedSpotIndex";
 
 export const IndexLikedSpotLayout = () => {
   const { spotId } = useParams();

--- a/src/contexts/SpotsContext.js
+++ b/src/contexts/SpotsContext.js
@@ -5,14 +5,31 @@ const SpotsContext = createContext();
 
 export function SpotsContextProvider({ children }) {
   const [ spots, setSpots ] = useState();
+  const [ likedSpots, setLikedSpots ] = useState();
 
   const loadSpots = async () => {
     const spotsData = await getSpots();
     setSpots(spotsData);
+    return spotsData;
   };
 
+  const loadLikedSpots = async (userId) => {
+    const spotsData = await getSpots();
+    const likedSpotData = await spotsData.filter(spot =>
+      spot.likes.some(like => parseInt(like.user_id) === parseInt(userId)));
+    setLikedSpots(likedSpotData);
+    return likedSpotData;
+  }
+
   return (
-    <SpotsContext.Provider value={{ spots, setSpots, loadSpots }} >
+    <SpotsContext.Provider value={{
+      spots,
+      setSpots,
+      loadSpots,
+      loadLikedSpots,
+      likedSpots,
+      setLikedSpots
+    }} >
       {children}
     </SpotsContext.Provider>
   );

--- a/src/features/spots/components/LikedSpotIndex.jsx
+++ b/src/features/spots/components/LikedSpotIndex.jsx
@@ -1,24 +1,21 @@
 import { Marker } from '@vis.gl/react-google-maps';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSpotsContext } from '../../../contexts/SpotsContext';
+import { useParams } from "react-router-dom";
 
 export const LikedSpotIndex = ({handleMarkerClick}) => {
-  const { spots, loadSpots } = useSpotsContext();
-  const { currentUser } = useFirebaseAuth();
-  sonst [ likedSpots, setLikedSpots ] = useState();
+  const { userId } = useParams();
+  const { likedSpots, loadLikedSpots } = useSpotsContext();
 
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        await loadSpots();
-        const likedSpotList = await spots.filter(spot => spot.likes.some(
-          like => parseInt(like.user_id) === parseInt(currentUser.id)));
-          setLikedSpots(likedSpotList);
-      } catch (error) {
-        console.error('Failed to fetch user data', error);
+      const fetchData = async () => {
+        try {
+          loadLikedSpots(userId);
+        } catch (error) {
+          console.error('Failed to fetch user data', error);
+        }
       }
-    }
-    fetchData();
+      fetchData();
   }, [])
 
   return (

--- a/src/features/spots/components/LikedSpotIndex.jsx
+++ b/src/features/spots/components/LikedSpotIndex.jsx
@@ -1,0 +1,41 @@
+import { Marker } from '@vis.gl/react-google-maps';
+import { useEffect, useState } from 'react';
+import { useSpotsContext } from '../../../contexts/SpotsContext';
+
+export const LikedSpotIndex = ({handleMarkerClick}) => {
+  const { spots, loadSpots } = useSpotsContext();
+  const { currentUser } = useFirebaseAuth();
+  sonst [ likedSpots, setLikedSpots ] = useState();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await loadSpots();
+        const likedSpotList = await spots.filter(spot => spot.likes.some(
+          like => parseInt(like.user_id) === parseInt(currentUser.id)));
+          setLikedSpots(likedSpotList);
+      } catch (error) {
+        console.error('Failed to fetch user data', error);
+      }
+    }
+    fetchData();
+  }, [])
+
+  return (
+    <>
+      {likedSpots ? (
+        likedSpots.map((spot) =>
+          <Marker
+            key={spot.id}
+            position={{
+              lat: spot.lat,
+              lng: spot.lng
+            }}
+            onClick={() => handleMarkerClick(spot.id)}
+          />)
+      ) : (
+        ""
+      )}
+    </>
+  )
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -3,6 +3,7 @@ import { MainLayout } from '../components/Layout/MainLayout';
 import { CreateSpotLayout } from '../components/Layout/CreateSpotLayout';
 import { IndexSpotLayout } from '../components/Layout/IndexSpotLayout';
 import { UserLayout } from '../components/Layout/UserLayout';
+import { IndexLikedSpotLayout } from '../components/Layout/IndexLikedSpotLayout';
 
 export const AppRoutes = () => {
   return (
@@ -12,6 +13,7 @@ export const AppRoutes = () => {
         <Route path="/map" element={<IndexSpotLayout />} />
         <Route path="spots/:spotId" element={<IndexSpotLayout />} />
         <Route path="/users/:userId" element={<UserLayout />} />
+        <Route path="/users/:userId/likes" element={<IndexLikedSpotLayout />} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
## 概要
- ユーザーがいいねしたスポットのみをフィルターし、マーカーとしてマップ上に表示するようにしました。
[動画](https://i.gyazo.com/397fac734f87c9e68cca62f068d8522a.gif)
## 実施したこと
- [x] いいねしたスポット一覧を表示する画面を作成
  - [x] マップ上にマーカーを表示するレイアウトを作成
  - [x] マーカーを表示するコンポーネントを作成
  - [x] ユーザーがいいね済みのスポットをフィルターする機能を作成
  - [x] ルーティングを作成
## 実施しなかったこと
- 「いいねしたスポットの一覧を見る」リンクの作成
 => 現状はURLパス直入力でのみ、対象の画面に遷移可能です。
　　どのような方法で遷移させるか、検討中です。(ボタンorリンクを想定)
## 懸念事項
- いいねしたスポットをマップに表示している際、マーカーをクリックすると
　スポット一覧(`/maps`)のスポット詳細画面(`/spots/:spotId`)に遷移するようになっています。
(せっかくユーザーがいいねしたスポットのみを表示させたのに、全てのスポットの画面に遷移してしまう)
 => 別途、スポット詳細画面を作成するか、検討します。
[動画](https://i.gyazo.com/9a67c041d9d31b244cec05bba59eb904.gif)
