### PR TITLE
スポット削除機能

### DIFF
--- a/src/components/Elements/Buttons/DeleteButton.jsx
+++ b/src/components/Elements/Buttons/DeleteButton.jsx
@@ -1,9 +1,25 @@
 import { Box, Typography } from "@mui/material"
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import { deleteSpot } from "../../../features/spots/api/deleteSpot";
+import { useNavigate } from "react-router-dom";
+import { useSpotsContext } from "../../../contexts/SpotsContext";
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 
-export const DeleteButton = () => {
-  const handleSpotDelete = () => {
+export const DeleteButton = ({ currentUser, spot }) => {
+  const { loadSpots } = useSpotsContext();
+  const { setMessage, setIsSuccessMessage } = useFlashMessage();
+  const navigate = useNavigate();
 
+  const handleSpotDelete = async () => {
+    try {
+      await deleteSpot(currentUser, spot.id, setIsSuccessMessage);
+      await loadSpots();
+      setMessage("削除しました");
+      navigate('/map');
+    } catch (error) {
+      setMessage(error.message);
+      navigate('/map');
+    }
   }
 
   return (

--- a/src/components/Elements/Buttons/DeleteButton.jsx
+++ b/src/components/Elements/Buttons/DeleteButton.jsx
@@ -1,0 +1,23 @@
+import { Box, Typography } from "@mui/material"
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+
+export const DeleteButton = () => {
+  const handleSpotDelete = () => {
+
+  }
+
+  return (
+    <Box
+      sx={{p: 0, m: 0}}
+      display={"flex"}
+      flexDirection={"row"}
+      color={"red"}
+      onClick={handleSpotDelete}
+    >
+      <DeleteForeverIcon fontSize="small" sx={{mr: 1}} />
+      <Typography >
+        削除
+      </Typography>
+    </Box>
+  )
+}

--- a/src/components/FlashMessages/FlashMessage.jsx
+++ b/src/components/FlashMessages/FlashMessage.jsx
@@ -4,20 +4,18 @@ import Fade from '@mui/material/Fade';
 import Slide from '@mui/material/Slide';
 import { useLocation } from 'react-router-dom';
 import { Alert } from '@mui/material';
-
+import { useFlashMessage } from '../../contexts/FlashMessageContext';
 
 function SlideTransition(props) {
   return <Slide {...props} direction="up" />;
 }
 
-export default function TransitionsSnackbar() {
+export default function FlashMessage() {
   const [state, setState] = useState({
     open: true,
     Transition: Fade,
   });
-
-  const location = useLocation();
-  const message = location.state?.message;
+  const { message, isSuccessMessage } = useFlashMessage();
 
   useState(() => {
     if (message) {
@@ -35,24 +33,36 @@ export default function TransitionsSnackbar() {
     });
   };
 
-  return (
-    <div>
-      <Snackbar
-        open={state.open}
-        onClose={handleClose}
-        TransitionComponent={state.Transition}
-        message={message}
-        key={state.Transition.name}
-        autoHideDuration={1200}
-      >
-        <Alert
-          severity="success"
-          variant="filled"
-          sx={{ width: '100%' }}
+  if (message) {
+    return (
+      <div>
+        <Snackbar
+          open={state.open}
+          onClose={handleClose}
+          TransitionComponent={state.Transition}
+          message={message}
+          key={state.Transition.name}
+          autoHideDuration={1200}
         >
-          {message}
-        </Alert>
-      </Snackbar>
-    </div>
-  );
+          {isSuccessMessage ?
+          <Alert
+            severity="success"
+            variant="filled"
+            sx={{ width: '100%' }}
+          >
+            {message}
+          </Alert>
+          :
+          <Alert
+            severity="warning"
+            variant="filled"
+            sx={{ width: '100%' }}
+          >
+            {message}
+          </Alert>
+          }
+        </Snackbar>
+      </div>
+    );
+  }
 }

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1,14 +1,14 @@
 import { Box } from "@mui/material";
-import TransitionsSnackbar from "../FlashMessages/FlashMessage";
 import Header from "../Header/Header";
 import { Outlet } from "react-router-dom";
+import FlashMessage from "../FlashMessages/FlashMessage";
 
 export const MainLayout = () => {
   return (
     <Box sx={{height: "calc(100vh - 64px)", width: "100%"}}>
       <Header />
       <Outlet />
-      <TransitionsSnackbar />
+      <FlashMessage />
     </Box>
   )
 }

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -6,7 +6,6 @@ import { useParams } from "react-router-dom";
 import Spinner from "../Elements/Spinner/Spinner";
 import { getUsers } from "../../features/users/api/getUsers";
 import { SpotListTab } from "../../features/users/components/SpotListTab";
-import { DeleteButton } from "../Elements/Buttons/DeleteButton";
 
 export const UserLayout = () => {
   const { loadSpots } = useSpotsContext();
@@ -37,7 +36,6 @@ export const UserLayout = () => {
 
   return (
     <>
-      <DeleteButton />
       <UserProfile userInfo={userInfo}/>
       <SpotListTab userInfo={userInfo}/>
     </>

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -6,6 +6,7 @@ import { useParams } from "react-router-dom";
 import Spinner from "../Elements/Spinner/Spinner";
 import { getUsers } from "../../features/users/api/getUsers";
 import { SpotListTab } from "../../features/users/components/SpotListTab";
+import { DeleteButton } from "../Elements/Buttons/DeleteButton";
 
 export const UserLayout = () => {
   const { loadSpots } = useSpotsContext();
@@ -36,6 +37,7 @@ export const UserLayout = () => {
 
   return (
     <>
+      <DeleteButton />
       <UserProfile userInfo={userInfo}/>
       <SpotListTab userInfo={userInfo}/>
     </>

--- a/src/contexts/FlashMessageContext.js
+++ b/src/contexts/FlashMessageContext.js
@@ -1,0 +1,18 @@
+import { createContext, useContext, useState } from "react";
+
+const FlashMessageContext = createContext();
+
+export const FlashMessageProvider = ({ children }) => {
+  const [message, setMessage] = useState();
+  const [ isSuccessMessage, setIsSuccessMessage ] = useState(false);
+
+  return (
+    <FlashMessageContext.Provider
+      value={{ message, setMessage, isSuccessMessage, setIsSuccessMessage }}
+    >
+      {children}
+    </FlashMessageContext.Provider>
+  );
+};
+
+export const useFlashMessage = () => useContext(FlashMessageContext);

--- a/src/features/spots/api/deleteSpot.js
+++ b/src/features/spots/api/deleteSpot.js
@@ -1,0 +1,25 @@
+import { axios } from "../../../lib/axios";
+
+export const deleteSpot = async ( currentUser, spotId ) => {
+  const token = await currentUser?.getIdToken()
+
+  if (!token) {
+    throw new Error('No token found');
+  }
+  const config = {
+    headers: { authorization: `Bearer ${token}` },
+  };
+
+  try {
+    const res = await axios.delete(`/api/v1/spots/${spotId}`, config);
+    return res.data.message;
+  } catch (err) {
+    let message;
+    if (axios.isAxiosError(err) && err.response) {
+      console.error(err.response.data.message);
+    } else {
+      message = String(err);
+      console.error(message);
+    }
+  }
+}

--- a/src/features/spots/api/deleteSpot.js
+++ b/src/features/spots/api/deleteSpot.js
@@ -1,6 +1,7 @@
 import { axios } from "../../../lib/axios";
+import { isAxiosError } from 'axios';
 
-export const deleteSpot = async ( currentUser, spotId ) => {
+export const deleteSpot = async ( currentUser, spotId, setIsSuccessMessage ) => {
   const token = await currentUser?.getIdToken()
 
   if (!token) {
@@ -12,14 +13,16 @@ export const deleteSpot = async ( currentUser, spotId ) => {
 
   try {
     const res = await axios.delete(`/api/v1/spots/${spotId}`, config);
+    setIsSuccessMessage(true);
     return res.data.message;
   } catch (err) {
-    let message;
-    if (axios.isAxiosError(err) && err.response) {
-      console.error(err.response.data.message);
+    let message = '削除できませんでした';
+    if (isAxiosError(err) && err.response) {
+      message = err.response.data.message || message;
+      throw new Error(message);
     } else {
       message = String(err);
-      console.error(message);
+      throw new Error(message);
     }
   }
 }

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -33,16 +33,16 @@ export const SpotDetail = ({ spotId }) => {
             <Avatar src={selectedSpot.user.avatar} sx={{mr: 2}} ></Avatar>
             <Typography >{selectedSpot.user.name}</Typography>
           </Link>
-            <Typography >{selectedSpot.name}</Typography>
-            {selectedSpot.videos && selectedSpot.videos.length > 0 && (
-              selectedSpot.videos.map((video) => (
-                <iframe  src={`https://www.youtube.com/embed/${video.youtube_video_id}`} allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
-              ))
-            )}
-            <LikeButton
-              savedLikes={selectedSpot.likes}
-              selectedSpot={selectedSpot}
-            />
+          <Typography >{selectedSpot.name}</Typography>
+          {selectedSpot.videos && selectedSpot.videos.length > 0 && (
+            selectedSpot.videos.map((video) => (
+              <iframe src={`https://www.youtube.com/embed/${video.youtube_video_id}`} allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
+            ))
+          )}
+          <LikeButton
+            savedLikes={selectedSpot.likes}
+            selectedSpot={selectedSpot}
+          />
         </>
       }
     </Box>

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Spinner from "../../../components/Elements/Spinner/Spinner";
 import { LikeButton } from "../../../components/Elements/Buttons/LikeButton";
+import { DeleteButton } from "../../../components/Elements/Buttons/DeleteButton";
 
 export const SpotDetail = ({ spotId }) => {
   const { spots } = useSpotsContext();
@@ -34,6 +35,7 @@ export const SpotDetail = ({ spotId }) => {
             <Typography >{selectedSpot.user.name}</Typography>
           </Link>
           <Typography >{selectedSpot.name}</Typography>
+          <DeleteButton currentUser={currentUser} spot={selectedSpot} />
           {selectedSpot.videos && selectedSpot.videos.length > 0 && (
             selectedSpot.videos.map((video) => (
               <iframe src={`https://www.youtube.com/embed/${video.youtube_video_id}`} allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>

--- a/src/providers/app.jsx
+++ b/src/providers/app.jsx
@@ -2,6 +2,7 @@ import { AuthContextProvider } from "../contexts/AuthContext";
 import { BrowserRouter as Router } from 'react-router-dom';
 import { APIProvider } from '@vis.gl/react-google-maps';
 import { SpotsContextProvider } from "../contexts/SpotsContext";
+import { FlashMessageProvider } from "../contexts/FlashMessageContext";
 
 export const AppProvider = ({ children }) => {
   return (
@@ -9,7 +10,9 @@ export const AppProvider = ({ children }) => {
       <APIProvider apiKey={process.env.REACT_APP_GOOGLE_MAP_API_KEY} language='en'>
         <AuthContextProvider>
           <SpotsContextProvider>
-            {children}
+            <FlashMessageProvider>
+              {children}
+            </FlashMessageProvider>
           </SpotsContextProvider>
         </AuthContextProvider>
       </APIProvider>


### PR DESCRIPTION
## 概要
- スポット詳細に、削除ボタンを実装しました。
- 削除ボタンを押下すると、該当するスポットならびに関連付けされた動画といいねが削除されます。
- 削除処理の実施後は、`/map`(スポット一覧画面)に遷移し、削除成功or失敗のフラッシュメッセージを表示します。

[動画(スポット削除成功)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/743270a1-1a37-4208-9798-254753ca3a4f)

[動画(スポット削除失敗)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/2f5f8a5c-6de2-499b-850c-af9703641090)


## 実施したこと
- [x] 削除ボタンを作成
- [x] 削除ボタンを押した際に、Rails API側にデータを送信する機能を作成
- [x] フラッシュメッセージの作成
  - [x] フラッシュメッセージを共有するコンテクストを作成
  - [x] 削除ボタンにフラッシュメッセージを表示する機能を追加
  - [x] フラッシュメッセージを表示するコンポーネントを修正
    - [x] 成功時と失敗時それぞれのメッセージに色を設定  
  - [x] 削除完了のフラッシュメッセージを作成
  - [x] 削除未完了のフラッシュメッセージを作成
## 懸念事項
- 削除ボタン押下後、`/map`への遷移とともにフラッシュメッセージが表示されますが、
　続けて2回目以降、削除ボタンを押下してもフラッシュメッセージが表示されません。
[動画(422エラー=>404エラー)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f8213eea-13c7-4246-965b-f6bed92cedf5)
[動画(422エラー=>422エラー)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/3af48637-6f76-450b-8df0-e2f0862f81ae)
- 次Issueを作成し、解消予定です。
