### PR TITLE
スポット編集機能

### DIFF
--- a/src/components/Elements/Buttons/ConfigButton.jsx
+++ b/src/components/Elements/Buttons/ConfigButton.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Fade from '@mui/material/Fade';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import { IconButton } from '@mui/material';
+import { DeleteButton } from './DeleteButton';
+import { EditButton } from './EditButton';
+
+export const ConfigButton = ({ currentUser, selectedSpot, setEditing }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <IconButton
+        id="fade-button"
+        aria-controls={open ? 'fade-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={handleClick}
+        color='secondary'
+      >
+        <MoreHorizIcon />
+      </IconButton>
+      <Menu
+        id="fade-menu"
+        MenuListProps={{
+          'aria-labelledby': 'fade-button',
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        TransitionComponent={Fade}
+      >
+        <MenuItem onClick={handleClose} >
+          <EditButton currentUser={currentUser} spot={selectedSpot} setEditing={setEditing} />
+        </MenuItem>
+        <MenuItem onClick={handleClose} >
+          <DeleteButton currentUser={currentUser} spot={selectedSpot} />
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+}

--- a/src/components/Elements/Buttons/EditButton.jsx
+++ b/src/components/Elements/Buttons/EditButton.jsx
@@ -1,0 +1,31 @@
+import { Box,  IconButton,  Typography } from "@mui/material";
+import EditIcon from '@mui/icons-material/Edit';
+import { deleteSpot } from "../../../features/spots/api/deleteSpot";
+import { useSpotsContext } from "../../../contexts/SpotsContext";
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
+
+export const EditButton = ({ currentUser, spot }) => {
+  const { loadSpots } = useSpotsContext();
+  const { setMessage, setIsSuccessMessage } = useFlashMessage();
+
+  const handleSpotEdit = async () => {
+    try {
+      await deleteSpot(currentUser, spot.id, setIsSuccessMessage);
+      await loadSpots();
+      setMessage("編集が完了しました");
+    } catch (error) {
+      setMessage(error.message);
+    }
+  }
+
+  return (
+    <IconButton onClick={handleSpotEdit}>
+      <Box sx={{p: 0, m: 0}} display={"flex"} flexDirection={"row"} >
+        <EditIcon fontSize="small" sx={{mr: 1}} />
+        <Typography >
+          編集
+        </Typography>
+      </Box>
+    </IconButton>
+  )
+}

--- a/src/components/Elements/Buttons/EditButton.jsx
+++ b/src/components/Elements/Buttons/EditButton.jsx
@@ -24,13 +24,16 @@ export const EditButton = ({ currentUser, spot, setEditing }) => {
   }
 
   return (
-    <IconButton onClick={handleSpotEdit}>
-      <Box sx={{p: 0, m: 0}} display={"flex"} flexDirection={"row"} >
-        <EditIcon fontSize="small" sx={{mr: 1}} />
-        <Typography >
-          編集
-        </Typography>
-      </Box>
-    </IconButton>
+    <Box
+      sx={{p: 0, m: 0}}
+      display={"flex"}
+      flexDirection={"row"}
+      onClick={handleSpotEdit}
+    >
+      <EditIcon fontSize="small" sx={{mr: 1}} />
+      <Typography >
+        編集
+      </Typography>
+    </Box>
   )
 }

--- a/src/components/Elements/Buttons/EditButton.jsx
+++ b/src/components/Elements/Buttons/EditButton.jsx
@@ -3,12 +3,17 @@ import EditIcon from '@mui/icons-material/Edit';
 import { deleteSpot } from "../../../features/spots/api/deleteSpot";
 import { useSpotsContext } from "../../../contexts/SpotsContext";
 import { useFlashMessage } from "../../../contexts/FlashMessageContext";
+import { useState } from "react";
 
-export const EditButton = ({ currentUser, spot }) => {
+export const EditButton = ({ currentUser, spot, setEditing }) => {
   const { loadSpots } = useSpotsContext();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
 
   const handleSpotEdit = async () => {
+    setEditing(true);
+  }
+
+  const handleSpotUpdate = async () => {
     try {
       await deleteSpot(currentUser, spot.id, setIsSuccessMessage);
       await loadSpots();

--- a/src/features/spots/api/deleteSpot.js
+++ b/src/features/spots/api/deleteSpot.js
@@ -16,7 +16,7 @@ export const deleteSpot = async ( currentUser, spotId, setIsSuccessMessage ) => 
     setIsSuccessMessage(true);
     return res.data.message;
   } catch (err) {
-    let message = '編集に失敗しました';
+    let message = '削除に失敗しました';
     if (isAxiosError(err) && err.response) {
       message = err.response.data.message || message;
       throw new Error(message);

--- a/src/features/spots/api/deleteSpot.js
+++ b/src/features/spots/api/deleteSpot.js
@@ -16,7 +16,7 @@ export const deleteSpot = async ( currentUser, spotId, setIsSuccessMessage ) => 
     setIsSuccessMessage(true);
     return res.data.message;
   } catch (err) {
-    let message = '削除できませんでした';
+    let message = '編集に失敗しました';
     if (isAxiosError(err) && err.response) {
       message = err.response.data.message || message;
       throw new Error(message);

--- a/src/features/spots/api/updateSpot.js
+++ b/src/features/spots/api/updateSpot.js
@@ -1,4 +1,5 @@
 import { axios } from "../../../lib/axios";
+import { isAxiosError } from 'axios';
 
 export const updateSpot = async (currentUser, spotInfo) => {
   const token = await currentUser?.getIdToken();
@@ -21,12 +22,13 @@ export const updateSpot = async (currentUser, spotInfo) => {
     const res = await axios.put(`/api/v1/spots/${spotInfo.id}`, data, config);
     return res.data;
   } catch (err) {
-    let message;
-    if (axios.isAxiosError(err) && err.response) {
-      console.error(err.response.data.message);
+    let message = '編集に失敗しました';
+    if (isAxiosError(err) && err.response) {
+      message = err.response.data.message || message;
+      throw new Error(message);
     } else {
       message = String(err);
-      console.error(message);
+      throw new Error(message);
     }
   }
 }

--- a/src/features/spots/api/updateSpot.js
+++ b/src/features/spots/api/updateSpot.js
@@ -1,12 +1,6 @@
 import { axios } from "../../../lib/axios";
 
-export const updateSpot = async (
-    currentUser,
-    spotName,
-    spotDescription,
-    spotLatLng,
-    address
-  ) => {
+export const updateSpot = async (currentUser, spotInfo) => {
   const token = await currentUser?.getIdToken();
 
   if (!token) {
@@ -18,17 +12,13 @@ export const updateSpot = async (
 
   const data = {
     spot: {
-    name: spotName,
-    description: spotDescription,
-    lat: spotLatLng.lat,
-    lng: spotLatLng.lng,
-    address_components: address.address_components,
-    formatted_address: address.formatted_address,
+      name: spotInfo.name,
+      description: spotInfo.description,
     }
   }
 
   try {
-    const res = await axios.put("/api/v1/spots", data, config);
+    const res = await axios.put(`/api/v1/spots/${spotInfo.id}`, data, config);
     return res.data;
   } catch (err) {
     let message;

--- a/src/features/spots/api/updateSpot.js
+++ b/src/features/spots/api/updateSpot.js
@@ -1,0 +1,42 @@
+import { axios } from "../../../lib/axios";
+
+export const updateSpot = async (
+    currentUser,
+    spotName,
+    spotDescription,
+    spotLatLng,
+    address
+  ) => {
+  const token = await currentUser?.getIdToken();
+
+  if (!token) {
+    throw new Error('No token found');
+  }
+  const config = {
+    headers: { authorization: `Bearer ${token}` },
+  };
+
+  const data = {
+    spot: {
+    name: spotName,
+    description: spotDescription,
+    lat: spotLatLng.lat,
+    lng: spotLatLng.lng,
+    address_components: address.address_components,
+    formatted_address: address.formatted_address,
+    }
+  }
+
+  try {
+    const res = await axios.put("/api/v1/spots", data, config);
+    return res.data;
+  } catch (err) {
+    let message;
+    if (axios.isAxiosError(err) && err.response) {
+      console.error(err.response.data.message);
+    } else {
+      message = String(err);
+      console.error(message);
+    }
+  }
+}

--- a/src/features/spots/components/EditSpot.jsx
+++ b/src/features/spots/components/EditSpot.jsx
@@ -1,0 +1,101 @@
+import { Box, Button, TextField, Typography } from "@mui/material"
+import { useState } from "react"
+import RoomTwoToneIcon from '@mui/icons-material/RoomTwoTone';
+import { updateSpot } from "../api/updateSpot";
+import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
+import Switch from '@mui/material/Switch';
+import Spinner from "../../../components/Elements/Spinner/Spinner";
+
+const style = {
+  display: 'flex',
+  flexDirection: 'column',
+  width: '90%',
+  textAlign: 'center'
+}
+export const EditSpot = ({ spot, setEditing, title }) => {
+  const [ spotName, setSpotName ] = useState();
+  const [ spotDescription, setSpotDescription ] = useState("");
+  const { currentUser } = useFirebaseAuth();
+  const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
+
+  const label = { inputProps: { 'aria-label': 'Switch demo' } };
+
+  if (!currentUser || !spot) return <div><Spinner /></div>;
+  console.log(spot)
+  const latLng = {lat: spot.lat, lng: spot.lng};
+
+  const handleSpotUpdate = async (e) => {
+    e.preventDefault();
+    await updateSpot(currentUser, spotName, spotDescription, latLng, spot.address);
+    setEditing(false);
+  }
+
+  return (
+    <form onSubmit={handleSpotUpdate} >
+      <Box style={style} >
+        <Typography variant='h5' fontSize={"24px"}><RoomTwoToneIcon />{title}</Typography>
+        <TextField
+          id="spotName"
+          label="スポット名"
+          fullWidth
+          variant="outlined"
+          color="info"
+          margin="normal"
+          helperText="※必須項目です"
+          placeholder="表示されるスポット名"
+          defaultValue={spot.name}
+          name="spotName"
+          onChange={(e) => setSpotName(e.target.value)}
+        />
+        <TextField
+          id="outlined-multiline-static"
+          label="説明"
+          fullWidth
+          multiline
+          rows={2}
+          color='info'
+          placeholder="思い出や感想を入力してください"
+          margin="normal"
+          defaultValue={spot.description}
+          name='description'
+          onChange={(e) => setSpotDescription(e.target.value)}
+        />
+        <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>
+          <Typography>動画を自動で取得する</Typography>
+          <Switch
+            {...label}
+            defaultChecked
+            disabled
+            checked={isAutoFetchEnabled}
+            onChange={() => setIsAutoFetchEnabled(!isAutoFetchEnabled)}
+          />
+        </Box>
+        <Box sx={{pb: 3}}>
+          {isAutoFetchEnabled ? (
+            <>
+              <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
+              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography>
+            </>
+          ) : (
+            <>
+              <TextField label="YouTube動画URLを入力" ></TextField>
+              <Typography >https://www.youtube.com/</Typography>
+            </>
+          )}
+        </Box>
+        <Box >
+          <Button variant='text' onClick={() => setEditing(false)} >キャンセル</Button>
+          <Button
+            type='submit'
+            color='success'
+            variant='contained'
+            display={"flex"}
+            sx={{width: "150px"}}
+          >
+            保存する
+          </Button>
+        </Box>
+      </Box>
+    </form>
+  )
+}

--- a/src/features/spots/components/EditSpot.jsx
+++ b/src/features/spots/components/EditSpot.jsx
@@ -6,6 +6,7 @@ import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Switch from '@mui/material/Switch';
 import Spinner from "../../../components/Elements/Spinner/Spinner";
 import { useSpotsContext } from "../../../contexts/SpotsContext";
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 
 const style = {
   display: 'flex',
@@ -16,6 +17,7 @@ const style = {
 export const EditSpot = ({ spot, setEditing, title }) => {
   const { currentUser } = useFirebaseAuth();
   const { loadSpots } = useSpotsContext();
+  const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ spotName, setSpotName ] = useState();
   const [ spotDescription, setSpotDescription ] = useState("");
   const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
@@ -31,10 +33,16 @@ export const EditSpot = ({ spot, setEditing, title }) => {
   }
 
   const handleSpotUpdate = async (e) => {
-    e.preventDefault();
-    await updateSpot(currentUser, spotInfo);
-    await loadSpots();
-    setEditing(false);
+    try {
+      e.preventDefault();
+      await updateSpot(currentUser, spotInfo);
+      await loadSpots();
+      setIsSuccessMessage(true);
+      setMessage("編集が完了しました");
+      setEditing(false);
+    } catch (error) {
+      setMessage(error.message);
+    }
   }
 
   return (

--- a/src/features/spots/components/EditSpot.jsx
+++ b/src/features/spots/components/EditSpot.jsx
@@ -5,6 +5,7 @@ import { updateSpot } from "../api/updateSpot";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Switch from '@mui/material/Switch';
 import Spinner from "../../../components/Elements/Spinner/Spinner";
+import { useSpotsContext } from "../../../contexts/SpotsContext";
 
 const style = {
   display: 'flex',
@@ -13,20 +14,26 @@ const style = {
   textAlign: 'center'
 }
 export const EditSpot = ({ spot, setEditing, title }) => {
+  const { currentUser } = useFirebaseAuth();
+  const { loadSpots } = useSpotsContext();
   const [ spotName, setSpotName ] = useState();
   const [ spotDescription, setSpotDescription ] = useState("");
-  const { currentUser } = useFirebaseAuth();
   const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
 
   const label = { inputProps: { 'aria-label': 'Switch demo' } };
 
   if (!currentUser || !spot) return <div><Spinner /></div>;
-  console.log(spot)
-  const latLng = {lat: spot.lat, lng: spot.lng};
+
+  const spotInfo = {
+    id: spot.id,
+    name: spotName,
+    description: spotDescription,
+  }
 
   const handleSpotUpdate = async (e) => {
     e.preventDefault();
-    await updateSpot(currentUser, spotName, spotDescription, latLng, spot.address);
+    await updateSpot(currentUser, spotInfo);
+    await loadSpots();
     setEditing(false);
   }
 

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -5,9 +5,8 @@ import { Link } from "react-router-dom";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Spinner from "../../../components/Elements/Spinner/Spinner";
 import { LikeButton } from "../../../components/Elements/Buttons/LikeButton";
-import { DeleteButton } from "../../../components/Elements/Buttons/DeleteButton";
-import { EditButton } from "../../../components/Elements/Buttons/EditButton";
 import { EditSpot } from "./EditSpot";
+import { ConfigButton } from "../../../components/Elements/Buttons/ConfigButton";
 
 export const SpotDetail = ({ spotId }) => {
   const { spots } = useSpotsContext();
@@ -38,8 +37,7 @@ export const SpotDetail = ({ spotId }) => {
             <Typography >{selectedSpot.user.name}</Typography>
           </Link>
           <Typography >{selectedSpot.name}</Typography>
-          <EditButton currentUser={currentUser} spot={selectedSpot} setEditing={setEditing} />
-          <DeleteButton currentUser={currentUser} spot={selectedSpot} />
+          <ConfigButton currentUser={currentUser} selectedSpot={selectedSpot} setEditing={setEditing} />
           {selectedSpot.videos && selectedSpot.videos.length > 0 && (
             selectedSpot.videos.map((video) => (
               <iframe

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -7,11 +7,13 @@ import Spinner from "../../../components/Elements/Spinner/Spinner";
 import { LikeButton } from "../../../components/Elements/Buttons/LikeButton";
 import { DeleteButton } from "../../../components/Elements/Buttons/DeleteButton";
 import { EditButton } from "../../../components/Elements/Buttons/EditButton";
+import { EditSpot } from "./EditSpot";
 
 export const SpotDetail = ({ spotId }) => {
   const { spots } = useSpotsContext();
   const [ selectedSpot, setSelectedSpot ] = useState();
   const { currentUser } = useFirebaseAuth();
+  const [ editing, setEditing ] = useState(false);
 
   useEffect(() => {
     if (spots) {
@@ -26,7 +28,7 @@ export const SpotDetail = ({ spotId }) => {
 
   return (
     <Box >
-      {selectedSpot &&
+      {selectedSpot && !editing ?
         <>
           <Link
             to={`/users/${selectedSpot.user.id}`}
@@ -36,11 +38,16 @@ export const SpotDetail = ({ spotId }) => {
             <Typography >{selectedSpot.user.name}</Typography>
           </Link>
           <Typography >{selectedSpot.name}</Typography>
-          <EditButton currentUser={currentUser} spot={selectedSpot} />
+          <EditButton currentUser={currentUser} spot={selectedSpot} setEditing={setEditing} />
           <DeleteButton currentUser={currentUser} spot={selectedSpot} />
           {selectedSpot.videos && selectedSpot.videos.length > 0 && (
             selectedSpot.videos.map((video) => (
-              <iframe src={`https://www.youtube.com/embed/${video.youtube_video_id}`} allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
+              <iframe
+                src={`https://www.youtube.com/embed/${video.youtube_video_id}`}
+                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              >
+              </iframe>
             ))
           )}
           <LikeButton
@@ -48,6 +55,8 @@ export const SpotDetail = ({ spotId }) => {
             selectedSpot={selectedSpot}
           />
         </>
+      :
+        <EditSpot spot={selectedSpot} setEditing={setEditing} title={"スポット編集"} />
       }
     </Box>
   )

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -6,6 +6,7 @@ import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Spinner from "../../../components/Elements/Spinner/Spinner";
 import { LikeButton } from "../../../components/Elements/Buttons/LikeButton";
 import { DeleteButton } from "../../../components/Elements/Buttons/DeleteButton";
+import { EditButton } from "../../../components/Elements/Buttons/EditButton";
 
 export const SpotDetail = ({ spotId }) => {
   const { spots } = useSpotsContext();
@@ -35,6 +36,7 @@ export const SpotDetail = ({ spotId }) => {
             <Typography >{selectedSpot.user.name}</Typography>
           </Link>
           <Typography >{selectedSpot.name}</Typography>
+          <EditButton currentUser={currentUser} spot={selectedSpot} />
           <DeleteButton currentUser={currentUser} spot={selectedSpot} />
           {selectedSpot.videos && selectedSpot.videos.length > 0 && (
             selectedSpot.videos.map((video) => (


### PR DESCRIPTION
## 概要
- スポット編集機能を実装しました。
- 編集ボタンは、スポット詳細画面に配置した「…」ボタンを押下した際に、削除ボタンと並んで表示されます。
- 編集ボタンを押下すると、スポット編集フォームが表示され、「保存する」ボタンを押下すると
スポット情報が更新されます。
- 編集が成功した場合、失敗した場合それぞれにフラッシュメッセージが表示されます。

[動画(スポット編集成功)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/cca6b689-54a9-4a21-a4ff-a770dd6ae918)

[動画(スポット編集失敗)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/3a0130a9-3678-4a8e-9ab3-59197ad141aa)

## 実施したこと
- [x] スポット情報を編集する画面を作成
- [x] 編集後のスポット情報をRails側に送信する処理を作成
- [x] スポット詳細画面に編集ボタンを表示し、 編集ボタンを押下した際にスポット編集画面を表示する機能を追加
- [x] 編集完了時にリダイレクトする処理を作成
- [x] 編集ボタンと削除ボタンを表示させるための「…」ボタンを作成
- [x] 編集完了時のフラッシュメッセージを作成
- [x] 編集失敗時のフラッシュメッセージを作成

## 実施しなかったこと
- 編集ボタンと削除ボタンを表示する条件分岐(ログイン中のユーザーが投稿したスポットに限り表示する)は設定していません。