### PR TITLE
ログイン前後での画面表示の切り替え機能

### DIFF
--- a/src/components/Elements/Buttons/LikeButton.jsx
+++ b/src/components/Elements/Buttons/LikeButton.jsx
@@ -5,6 +5,7 @@ import { createLike } from "../../../features/likes/api/createLike";
 import { deleteLike } from "../../../features/likes/api/deleteLike";
 import { useSpotsContext } from "../../../contexts/SpotsContext";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
+import MessageModal from "../Modals/MessageModal";
 
 export const LikeButton = ({ savedLikes, selectedSpot }) => {
   const [ likedCount, setLikedCount ] = useState(0);
@@ -12,6 +13,11 @@ export const LikeButton = ({ savedLikes, selectedSpot }) => {
   const [ on, setOn ] = useState(false);
   const { spots, loadSpots } = useSpotsContext();
   const { currentUser, userId } = useFirebaseAuth();
+  const [ open, setOpen ] = useState(false);
+
+  const title = "ログインすると「いいね」ができます！";
+  const body = "投稿者に気持ちを伝えましょう！"
+  const icon = "😘 ❤️";
 
   // スポットにsavedLikes(いいね配列)が存在していれば、配列の長さを取得して、いいね数とする
   useEffect(() => {
@@ -50,13 +56,21 @@ export const LikeButton = ({ savedLikes, selectedSpot }) => {
         setOn(false);
       }
       loadSpots();
-    // } else {
-      // setOpen(true);
+    } else {
+      setOpen(true);
     }
   };
 
   return (
     <>
+      <MessageModal
+        open={open}
+        setOpen={setOpen}
+        title={title}
+        body={body}
+        icon={icon}
+        button={"login"}
+      />
       <Button
         onClick={handleLikeButtonClick}
         sx={{height: "30px", width: "10px", pl: 4}}

--- a/src/components/Elements/Buttons/LikeButton.jsx
+++ b/src/components/Elements/Buttons/LikeButton.jsx
@@ -11,7 +11,7 @@ export const LikeButton = ({ savedLikes, selectedSpot }) => {
   const [ likeId, setLikeId ] = useState();
   const [ on, setOn ] = useState(false);
   const { spots, loadSpots } = useSpotsContext();
-  const { currentUser } = useFirebaseAuth();
+  const { currentUser, userId } = useFirebaseAuth();
 
   // スポットにsavedLikes(いいね配列)が存在していれば、配列の長さを取得して、いいね数とする
   useEffect(() => {
@@ -23,8 +23,8 @@ export const LikeButton = ({ savedLikes, selectedSpot }) => {
   // ログイン中のユーザーがいいね済みであれば、いいねidを特定する
   // ログイン中のユーザーがいいね済みであれば、いいね済みボタンを表示する
   useEffect(() => {
-    if (currentUser && savedLikes) {
-      const likeByCurrentUser = savedLikes.find(like => like.user_id === parseInt(currentUser.id));
+    if (currentUser && userId && savedLikes) {
+      const likeByCurrentUser = savedLikes.find(like => like.user_id === parseInt(userId));
 
       if (likeByCurrentUser && likeByCurrentUser !== null) {
         setLikeId(likeByCurrentUser.id);

--- a/src/components/Elements/Buttons/LikeButton.jsx
+++ b/src/components/Elements/Buttons/LikeButton.jsx
@@ -35,7 +35,7 @@ export const LikeButton = ({ savedLikes, selectedSpot }) => {
     } else {
       setOn(false);
     }
-  }, [currentUser, savedLikes, spots])
+  }, [currentUser, savedLikes, spots, userId])
 
   // いいねボタンを押した時の処理
   // いいね済みでなければ、いいねを作成し、いいね済みボタンを表示する

--- a/src/components/Elements/Modals/MessageModal.jsx
+++ b/src/components/Elements/Modals/MessageModal.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Modal from '@mui/material/Modal';
+import CloseIcon from '@mui/icons-material/Close';
+import { IconButton } from '@mui/material';
+import { SignInButton } from '../../../features/auth/components/SignInButton';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  // border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+  textAlign: "center"
+};
+
+export default function MessageModal({open, setOpen, title, body, icon, button}) {
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+  const buttonType = button;
+
+  return (
+    <div>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style}>
+          {buttonType === "close" && <IconButton onClick={handleClose}><CloseIcon variant={"contained"} color={"info"} /></IconButton>}
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            {title}
+          </Typography>
+          <Typography id="modal-modal-description" variant='h3' sx={{ mt: 2 }}>
+            {icon}
+          </Typography>
+          <Typography sx={{pt: 2}}>{body}</Typography>
+          <Box sx={{pt: 2}} textAlign={"center"}>
+            {buttonType === "login" && <SignInButton text={"ログイン"} variant={"contained"} color={"info"} />}
+          </Box>
+        </Box>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -95,7 +95,7 @@ export default function Header() {
       open={isMobileMenuOpen}
       onClose={handleMobileMenuClose}
     >
-      {currentUser ? (
+      {currentUser && currentUser === null ? (
         <div>
           <MenuItem>
             <IconButton
@@ -137,7 +137,7 @@ export default function Header() {
       )}
     </Menu>
   );
-
+console.log(currentUser)
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -20,7 +20,7 @@ import { WithdrawalButton } from '../../features/users/components/WithdrawalButt
 export default function Header() {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [mobileMoreAnchorEl, setMobileMoreAnchorEl] = React.useState(null);
-  const { currentUser } = useFirebaseAuth();
+  const { currentUser, userId } = useFirebaseAuth();
   const navigate = useNavigate();
 
   const isMenuOpen = Boolean(anchorEl);
@@ -44,7 +44,7 @@ export default function Header() {
   };
 
   const handleProfileOpen = () => {
-    navigate(`/users/${currentUser.id}`);
+    navigate(`/users/${userId}`);
   }
 
   const menuId = 'primary-search-account-menu';
@@ -64,7 +64,7 @@ export default function Header() {
       open={isMenuOpen}
       onClose={handleMenuClose}
     >
-      {currentUser ?
+      {currentUser && currentUser !== null ?
       <div>
         <MenuItem onClick={handleProfileOpen}>
           <AccountCircle sx={{pr :1}}/>ユーザー情報
@@ -72,7 +72,7 @@ export default function Header() {
       </div>
       :
         <MenuItem onClick={handleMenuClose}>
-          <SignInButton text={"ログイン"} />
+          <SignInButton text={"ログイン"} currentUser={currentUser} />
         </MenuItem>
       }
     </Menu>
@@ -131,13 +131,13 @@ export default function Header() {
             aria-haspopup="true"
             color="inherit"
           > */}
-          <Typography ><SignInButton text={"ログイン"} /></Typography>
+          <Typography ><SignInButton text={"ログイン"} currentUser={currentUser} /></Typography>
           {/* </IconButton> */}
         </MenuItem>
       )}
     </Menu>
   );
-console.log(currentUser)
+
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -44,6 +44,7 @@ export default function Header() {
   };
 
   const handleProfileOpen = () => {
+    handleMenuClose();
     navigate(`/users/${userId}`);
   }
 
@@ -159,8 +160,8 @@ export default function Header() {
           >
             BackHacker.
           </Typography>
-          <LogOutButton />
-          <WithdrawalButton />
+          {/* <LogOutButton />
+          <WithdrawalButton /> */}
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             <IconButton

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -3,14 +3,44 @@ import { CreateSpot } from "../../features/spots/components/CreateSpot"
 import { MapView } from "../Map/MapView";
 import { useState } from "react";
 import { Marker } from '@vis.gl/react-google-maps';
+import MessageModal from "../Elements/Modals/MessageModal";
+import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 
 export const CreateSpotLayout = () => {
+  const { currentUser } = useFirebaseAuth();
   const [ latLng, setLatLng ] = useState({});
+  const [ open, setOpen ] = useState(true);
 
   const handleMapClick = (e) => {
     const lat = parseFloat(e.detail.latLng.lat);
     const lng = parseFloat(e.detail.latLng.lng);
     setLatLng({lat: lat, lng: lng});
+  }
+
+  const createSpotModalMessage = {
+    title: "ログインすると動画を取得できます",
+    body: "街の様子をみんなにシェアしよう！",
+    icon: "📺 👀"
+  };
+
+  const searchFailureModal = {
+    title: "動画を取得できませんでした",
+    body: "山、砂漠、海などは避け、都市部をクリックして再度試してみてください 🙇‍♂️",
+    icon: "😭",
+    button: "close"
+  };
+
+  if (!currentUser) {
+    return (
+      <MessageModal
+        open={open}
+        setOpen={setOpen}
+        title={createSpotModalMessage.title}
+        body={createSpotModalMessage.body}
+        icon={createSpotModalMessage.icon}
+        button={"login"}
+      />
+    );
   }
 
   return (

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -9,7 +9,6 @@ import { SpotListTab } from "../../features/users/components/SpotListTab";
 
 export const UserLayout = () => {
   const { loadSpots } = useSpotsContext();
-  const { currentUser } = useFirebaseAuth();
   const { userId } = useParams();
   const [ userInfo, setUserInfo ] = useState();
 
@@ -18,8 +17,6 @@ export const UserLayout = () => {
   }, []);
 
   useEffect(() => {
-    if (!currentUser) return;
-
     const fetchData = async () => {
       try {
         const users = await getUsers();
@@ -30,9 +27,9 @@ export const UserLayout = () => {
       }
     }
     fetchData();
-  }, [currentUser, userId])
+  }, [userInfo, userId])
 
-  if (!currentUser) {
+  if (!userInfo) {
     return <div><Spinner /></div>;
   }
 

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -18,6 +18,8 @@ export const UserLayout = () => {
   }, []);
 
   useEffect(() => {
+    if (!currentUser) return;
+
     const fetchData = async () => {
       try {
         const users = await getUsers();

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useSpotsContext } from "../../contexts/SpotsContext";
 import { UserProfile } from "../../features/users/components/UserProfile"
-import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 import { useParams } from "react-router-dom";
 import Spinner from "../Elements/Spinner/Spinner";
 import { getUsers } from "../../features/users/api/getUsers";
@@ -27,7 +26,7 @@ export const UserLayout = () => {
       }
     }
     fetchData();
-  }, [userInfo, userId])
+  }, [userId])
 
   if (!userInfo) {
     return <div><Spinner /></div>;

--- a/src/features/auth/components/LogOutButton.jsx
+++ b/src/features/auth/components/LogOutButton.jsx
@@ -1,17 +1,14 @@
-import { getAuth, signOut } from "firebase/auth";
 import { Button } from "@mui/material";
 import LogoutIcon from '@mui/icons-material/Logout';
 import { useNavigate } from "react-router-dom";
+import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 
 export const LogOutButton = () => {
   const navigate = useNavigate();
+  const { logout } = useFirebaseAuth();
 
-  const handleSignOut = () => {
-    const auth = getAuth();
-    signOut(auth).then(() => {
-      navigate('/', { state: {message: "ログアウトしました"}} );
-    }).catch((error) => {
-    });
+  const handleSignOut = async () => {
+    await logout();
   };
 
   return (

--- a/src/features/auth/components/LogOutButton.jsx
+++ b/src/features/auth/components/LogOutButton.jsx
@@ -6,7 +6,6 @@ export const LogOutButton = () => {
   const { logout } = useFirebaseAuth();
 
   const handleSignOut = async () => {
-    console.log("ボタンが押されました")
     await logout();
   };
 

--- a/src/features/auth/components/LogOutButton.jsx
+++ b/src/features/auth/components/LogOutButton.jsx
@@ -1,13 +1,12 @@
 import { Button } from "@mui/material";
 import LogoutIcon from '@mui/icons-material/Logout';
-import { useNavigate } from "react-router-dom";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 
 export const LogOutButton = () => {
-  const navigate = useNavigate();
   const { logout } = useFirebaseAuth();
 
   const handleSignOut = async () => {
+    console.log("ボタンが押されました")
     await logout();
   };
 

--- a/src/features/auth/components/SignInButton.jsx
+++ b/src/features/auth/components/SignInButton.jsx
@@ -2,9 +2,11 @@ import { axios } from '../../../lib/axios';
 import { useFirebaseAuth } from '../../../hooks/useFirebaseAuth';
 import { Button, Typography } from '@mui/material';
 import { Login } from '@mui/icons-material';
+import { useFlashMessage } from '../../../contexts/FlashMessageContext';
 
-export const SignInButton = ({ text }) => {
+export const SignInButton = ({ text, currentUser }) => {
   const { loginWithGoogle } = useFirebaseAuth();
+  const { setMessage } = useFlashMessage();
 
   const handleGoogleLogin = () => {
     const verifyIdToken = async () => {
@@ -20,7 +22,8 @@ export const SignInButton = ({ text }) => {
       };
 
       try {
-        axios.post("/api/v1/authentication", null, config);
+        const res = await axios.post("/api/v1/authentication", null, config);
+        return res.data;
       } catch (err) {
         let message;
         if (axios.isAxiosError(err) && err.response) {
@@ -31,7 +34,8 @@ export const SignInButton = ({ text }) => {
         }
       }
     };
-    verifyIdToken();
+    const res = verifyIdToken();
+    setMessage(res.message);
   };
 
   return (

--- a/src/features/auth/components/SignInButton.jsx
+++ b/src/features/auth/components/SignInButton.jsx
@@ -4,7 +4,7 @@ import { Button, Typography } from '@mui/material';
 import { Login } from '@mui/icons-material';
 import { useFlashMessage } from '../../../contexts/FlashMessageContext';
 
-export const SignInButton = ({ text, currentUser }) => {
+export const SignInButton = ({ text, currentUser, variant, color }) => {
   const { loginWithGoogle } = useFirebaseAuth();
   const { setMessage } = useFlashMessage();
 
@@ -39,7 +39,7 @@ export const SignInButton = ({ text, currentUser }) => {
   };
 
   return (
-    <Button onClick={handleGoogleLogin} size="large"  >
+    <Button onClick={handleGoogleLogin} size="large" variant={variant} color={color}  >
       <Typography fontWeight={"bold"} >
         {text}
       </Typography>

--- a/src/features/auth/components/SignInButton.jsx
+++ b/src/features/auth/components/SignInButton.jsx
@@ -11,6 +11,10 @@ export const SignInButton = ({ text }) => {
       const user = await loginWithGoogle();
       const token = await user?.getIdToken();
 
+      if (!token) {
+        throw new Error('No token found');
+      }
+
       const config = {
         headers: { authorization: `Bearer ${token}` },
       };

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -11,7 +11,7 @@ import { ConfigButton } from "../../../components/Elements/Buttons/ConfigButton"
 export const SpotDetail = ({ spotId }) => {
   const { spots } = useSpotsContext();
   const [ selectedSpot, setSelectedSpot ] = useState();
-  const { currentUser } = useFirebaseAuth();
+  const { currentUser, userId } = useFirebaseAuth();
   const [ editing, setEditing ] = useState(false);
 
   useEffect(() => {
@@ -37,7 +37,13 @@ export const SpotDetail = ({ spotId }) => {
             <Typography >{selectedSpot.user.name}</Typography>
           </Link>
           <Typography >{selectedSpot.name}</Typography>
-          <ConfigButton currentUser={currentUser} selectedSpot={selectedSpot} setEditing={setEditing} />
+          { userId === selectedSpot.user.id &&
+            <ConfigButton
+              currentUser={currentUser}
+              selectedSpot={selectedSpot}
+              setEditing={setEditing}
+            />
+          }
           {selectedSpot.videos && selectedSpot.videos.length > 0 && (
             selectedSpot.videos.map((video) => (
               <iframe

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -21,7 +21,7 @@ export const SpotDetail = ({ spotId }) => {
     }
   }, [spotId, spots, currentUser]);
 
-  if (!selectedSpot || !currentUser) {
+  if (!selectedSpot) {
     return <div><Spinner /></div>;
   }
 

--- a/src/features/users/components/UserProfile.jsx
+++ b/src/features/users/components/UserProfile.jsx
@@ -5,7 +5,7 @@ import { WithdrawalButton } from "./WithdrawalButton";
 import { LogOutButton } from "../../auth/components/LogOutButton";
 
 export const UserProfile = ({ userInfo }) => {
-  const { currentUser, loading } = useFirebaseAuth();
+  const { loading } = useFirebaseAuth();
 
   if (loading) {
     return <div><Spinner /></div>;

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -19,18 +19,15 @@ export const WithdrawalButton = () => {
     const currentUser = auth.currentUser;
 
     if (currentUser) {
-      // 最近サインインしていないとエラーになってしまうので、再認証してクレデンシャルを取得
       login().then((result) => {
         const credential = GoogleAuthProvider.credentialFromResult(result);
         reauthenticateWithCredential(currentUser, credential)
         .then(() => {
-          // User re-authenticated.
           deleteUserFromFirebase(currentUser)
           .then(() => {
-            // User deleted.
-            if (currentUser?.id) {
+            // if (currentUser?.id) {
               deleteDoc(doc(db, "users", currentUser.id));
-            }
+            // }
             deleteUser(currentUser).then((message) => {
               navigate("/", { state: { message: message } });
             }).catch ((error) => {

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -60,6 +60,6 @@ export const WithdrawalButton = () => {
   }
 
   return (
-    <IconButton onClick={withdrawalUser} >退会</IconButton>
+    <IconButton type="button" onClick={withdrawalUser} >退会</IconButton>
   )
 }

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -59,7 +59,6 @@ export const useFirebaseAuth = () => {
       const fetchUserData = async () => {
         const userData = await getUser(currentUser);
         setUserId(userData.id)
-        console.log("userData.id", userData.id)
       }
       fetchUserData();
     }

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -6,13 +6,13 @@ import {
   signOut,
   signInWithPopup,
   GoogleAuthProvider,
-  getAuth,
 } from "firebase/auth";
 import { getUser } from "../features/users/api/getUser";
 
 export const useFirebaseAuth = () => {
   const [currentUser, setCurrentUser] = useState();
   const [loading, setLoading] = useState(true);
+  const [ userId, setUserId ] = useState();
 
   const navigate = useNavigate();
 
@@ -22,7 +22,7 @@ export const useFirebaseAuth = () => {
 
     if (result) {
       const user = result.user;
-
+      setCurrentUser(user);
       navigate("/");
       return user;
     }
@@ -34,7 +34,7 @@ export const useFirebaseAuth = () => {
   };
 
   const logout = async () => {
-    await signOut(auth).then(clear());
+    await signOut(auth).then(clear);
     navigate("/", { state: {message: "ログアウトしました"}});
   };
 
@@ -42,9 +42,9 @@ export const useFirebaseAuth = () => {
     if (!user) {
       setLoading(false);
       setCurrentUser(null);
+      setUserId(null);
       return;
     }
-
     setCurrentUser(user);
     setLoading(false);
   };
@@ -57,8 +57,9 @@ export const useFirebaseAuth = () => {
   useEffect(() => {
     if (currentUser) {
       const fetchUserData = async () => {
-        const user = await getUser(currentUser);
-        currentUser.id = user.id;
+        const userData = await getUser(currentUser);
+        setUserId(userData.id)
+        console.log("userData.id", userData.id)
       }
       fetchUserData();
     }
@@ -70,5 +71,6 @@ export const useFirebaseAuth = () => {
     loading,
     loginWithGoogle,
     logout,
+    userId
   };
 }

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -6,6 +6,7 @@ import {
   signOut,
   signInWithPopup,
   GoogleAuthProvider,
+  getAuth,
 } from "firebase/auth";
 import { getUser } from "../features/users/api/getUser";
 
@@ -32,18 +33,18 @@ export const useFirebaseAuth = () => {
     setLoading(false);
   };
 
-  const logout = () => {
-    signOut(auth).then(clear);
-    navigate("/");
+  const logout = async () => {
+    await signOut(auth).then(clear());
+    navigate("/", { state: {message: "ログアウトしました"}});
   };
 
   const nextOrObserver = async (user) => {
     if (!user) {
       setLoading(false);
+      setCurrentUser(null);
       return;
     }
 
-    setLoading(true);
     setCurrentUser(user);
     setLoading(false);
   };


### PR DESCRIPTION
## 概要
- ログイン前後で画面の表示を切り替えるように修正しました。
## 実施したこと
- [x] ヘッダーのプロフィールボタンの表示
  - [x] ログインしていない場合は、ログインボタンを表示する
[動画](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f82250f9-1cb4-46bc-aca3-e0f3e4b50350)
  - [x] ログインしている場合は、ユーザー情報ページへのリンクを表示する
[動画](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f144410f-6146-4124-8723-a477f9258e69)

- [x] いいねボタンの動作
  - [x] ログインしている場合は、いいねボタンを動作させる
  - [x] ログインしていない場合は、ログインを促すモーダルを表示する
[動画](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/af80bdaa-b9c7-4ce8-b17f-5664479205b9)
    - [x] ログインを促すモーダルを作成する

- [x] 新規投稿画面の動作
  - [x] ログインしている場合は、新規投稿画面へ遷移させる
  - [x] ログインしていない場合は、ログインを促すモーダルを表示する
[動画(ログイン前に新規投稿画面にアクセス)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/fe4a5d64-479f-4109-8494-7834a75f2c49)

- [x] 投稿編集・削除ボタンの表示
  - [x] ログインしているユーザーの投稿の場合、編集・削除ボタンを表示する
[動画(ログイン中のユーザーが投稿したスポット)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/e364e94b-6ab2-4505-a6d9-2e7fad6c6d92)
[動画(ログイン中のユーザー以外が投稿したスポット)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/9660e519-b1b2-4f6d-a7cc-0c12a6a31eae)
