### PR TITLE
画面遷移の追加

### DIFF
--- a/src/components/Elements/Buttons/ShareButton.jsx
+++ b/src/components/Elements/Buttons/ShareButton.jsx
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material"
+import { IconButton } from "@mui/material"
 import XIcon from '@mui/icons-material/X';
 
 export const ShareButton = ({ url }) => {
@@ -7,8 +7,8 @@ export const ShareButton = ({ url }) => {
   }
 
   return (
-    <Button  onClick={handleClick} >
+    <IconButton onClick={handleClick} >
       <XIcon />
-    </Button>
+    </IconButton>
   );
 }

--- a/src/components/Elements/Buttons/ShareButton.jsx
+++ b/src/components/Elements/Buttons/ShareButton.jsx
@@ -1,0 +1,14 @@
+import { Button } from "@mui/material"
+import XIcon from '@mui/icons-material/X';
+
+export const ShareButton = ({ url }) => {
+  const handleClick = () => {
+    window.open(`${url}`, '_blank', 'noopener,noreferrer');
+  }
+
+  return (
+    <Button  onClick={handleClick} >
+      <XIcon />
+    </Button>
+  );
+}

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -21,10 +21,15 @@ const style = {
   textAlign: "center"
 };
 
-export default function SpotModal({open, setOpen, title, body, icon, button}) {
+export default function SpotModal({open, setOpen, title, body, icon, button, setLatLng}) {
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
   const buttonType = button;
+
+  const handleNextPostClick = () => {
+    setOpen(false);
+    setLatLng("");
+  }
 
   return (
     <div>
@@ -42,7 +47,7 @@ export default function SpotModal({open, setOpen, title, body, icon, button}) {
           <img src={icon} />
           <Typography sx={{pt: 2}}>{body}</Typography>
           <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
-            <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
+            <Button onClick={handleNextPostClick} text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
             <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"}  >投稿を確認する</Button>
             <ShareButton />
           </Box>

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Modal from '@mui/material/Modal';
+import CloseIcon from '@mui/icons-material/Close';
+import { IconButton } from '@mui/material';
+import { SignInButton } from '../../../features/auth/components/SignInButton';
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  // border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+  textAlign: "center"
+};
+
+export default function SpotModal({open, setOpen, title, body, icon, button}) {
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+  const buttonType = button;
+
+  return (
+    <div>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style}>
+          {buttonType === "close" && <IconButton onClick={handleClose}><CloseIcon variant={"contained"} color={"info"} /></IconButton>}
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            {title}
+          </Typography>
+          <img src={icon} />
+          <Typography sx={{pt: 2}}>{body}</Typography>
+          <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
+            <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
+            <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"}  >投稿を確認する</Button>
+            <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"} >シェア</Button>
+          </Box>
+        </Box>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -56,9 +56,24 @@ export default function SpotModal({open, setOpen, spot, setLatLng}) {
             <img src={spot.url} />
             <Typography sx={{pt: 2}}>{spot.body}</Typography>
             <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
-              <Button onClick={handleNextPost} text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
-              <Button onClick={handleSpotDetail} text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"}  >投稿を確認する</Button>
-              <ShareButton />
+              <Button
+                onClick={handleNextPost}
+                text={"ログイン"} sx={{width: "40%", my: 1}}
+                variant={"outlined"}
+                color={"info"}
+              >
+                続けて投稿する
+              </Button>
+              <Button
+                onClick={handleSpotDetail}
+                text={"ログイン"}
+                sx={{width: "40%", my: 1}}
+                variant={"contained"}
+                color={"info"}
+              >
+                投稿を確認する
+              </Button>
+              <ShareButton url={`https://twitter.com/share?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} (※PC💻環境より閲覧してください)&text=${spot.body}を投稿したよ！🎉【BackHacker.】で見に行かない？🌎%0a%0a`} />
             </Box>
           </Box>
         }

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -6,6 +6,7 @@ import Modal from '@mui/material/Modal';
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton } from '@mui/material';
 import { SignInButton } from '../../../features/auth/components/SignInButton';
+import { ShareButton } from '../Buttons/ShareButton';
 
 const style = {
   position: 'absolute',
@@ -43,7 +44,7 @@ export default function SpotModal({open, setOpen, title, body, icon, button}) {
           <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
             <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
             <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"}  >投稿を確認する</Button>
-            <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"} >シェア</Button>
+            <ShareButton />
           </Box>
         </Box>
       </Modal>

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -7,6 +7,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { IconButton } from '@mui/material';
 import { SignInButton } from '../../../features/auth/components/SignInButton';
 import { ShareButton } from '../Buttons/ShareButton';
+import { useNavigate } from 'react-router-dom';
 
 const style = {
   position: 'absolute',
@@ -21,14 +22,21 @@ const style = {
   textAlign: "center"
 };
 
-export default function SpotModal({open, setOpen, title, body, icon, button, setLatLng}) {
+export default function SpotModal({open, setOpen, spot, setLatLng}) {
+  const navigate = useNavigate();
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
-  const buttonType = button;
+  const buttonType = spot.button;
 
-  const handleNextPostClick = () => {
+  const handleNextPost = () => {
     setOpen(false);
     setLatLng("");
+  }
+
+  const handleSpotDetail = () => {
+    setOpen(false);
+    setLatLng("");
+    navigate(`/spots/${parseInt(spot.id)}`);
   }
 
   return (
@@ -39,19 +47,21 @@ export default function SpotModal({open, setOpen, title, body, icon, button, set
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
       >
-        <Box sx={style}>
-          {buttonType === "close" && <IconButton onClick={handleClose}><CloseIcon variant={"contained"} color={"info"} /></IconButton>}
-          <Typography id="modal-modal-title" variant="h6" component="h2">
-            {title}
-          </Typography>
-          <img src={icon} />
-          <Typography sx={{pt: 2}}>{body}</Typography>
-          <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
-            <Button onClick={handleNextPostClick} text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
-            <Button text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"}  >投稿を確認する</Button>
-            <ShareButton />
+        {spot &&
+          <Box sx={style}>
+            {buttonType === "close" && <IconButton onClick={handleClose}><CloseIcon variant={"contained"} color={"info"} /></IconButton>}
+            <Typography id="modal-modal-title" variant="h6" component="h2">
+              {spot.title}
+            </Typography>
+            <img src={spot.url} />
+            <Typography sx={{pt: 2}}>{spot.body}</Typography>
+            <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
+              <Button onClick={handleNextPost} text={"ログイン"} sx={{width: "40%", my: 1}} variant={"outlined"} color={"info"} >続けて投稿する</Button>
+              <Button onClick={handleSpotDetail} text={"ログイン"} sx={{width: "40%", my: 1}} variant={"contained"} color={"info"}  >投稿を確認する</Button>
+              <ShareButton />
+            </Box>
           </Box>
-        </Box>
+        }
       </Modal>
     </div>
   );

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -13,7 +13,7 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import MoreIcon from '@mui/icons-material/MoreVert';
 import { SignInButton } from '../../features/auth/components/SignInButton';
 import { useFirebaseAuth } from '../../hooks/useFirebaseAuth';
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { LogOutButton } from '../../features/auth/components/LogOutButton';
 import { WithdrawalButton } from '../../features/users/components/WithdrawalButton';
 
@@ -152,16 +152,19 @@ export default function Header() {
           >
             <MenuIcon />
           </IconButton>
-          <Typography
-            variant="h6"
-            noWrap
-            component="div"
-            sx={{ display: { xs: 'none', sm: 'block' } }}
-          >
-            BackHacker.
-          </Typography>
-          {/* <LogOutButton />
-          <WithdrawalButton /> */}
+          <Link
+              to={"/"}
+              style={{color: "inherit", textDecoration: "none"}}
+            >
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              sx={{ display: { xs: 'none', sm: 'block' } }}
+            >
+              BackHacker.
+            </Typography>
+          </Link>
           <Box sx={{ flexGrow: 1 }} />
           <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
             <IconButton
@@ -182,7 +185,7 @@ export default function Header() {
               onClick={handleProfileMenuOpen}
               color="inherit"
             >
-            {currentUser ? (
+            {currentUser && currentUser === null ? (
               <AccountCircle />
           ) : (
               <AccountCircle />

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -55,10 +55,11 @@ export const CreateSpotLayout = () => {
           body={createdSpot.body}
           icon={createdSpot.url}
           // button={"login"}
+          setLatLng={setLatLng}
         />
       }
       <Box sx={{height: "100%", width :"75%"}} >
-        <MapView latLng={latLng} setLatLng={setLatLng} onClick={handleMapClick} >
+        <MapView onClick={handleMapClick} >
           {latLng &&
             <Marker position={latLng} />
           }

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -51,10 +51,7 @@ export const CreateSpotLayout = () => {
         <SpotModal
           open={open}
           setOpen={setOpen}
-          title={createdSpot.title}
-          body={createdSpot.body}
-          icon={createdSpot.url}
-          // button={"login"}
+          spot={createdSpot}
           setLatLng={setLatLng}
         />
       }

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -5,11 +5,13 @@ import { useState } from "react";
 import { Marker } from '@vis.gl/react-google-maps';
 import MessageModal from "../Elements/Modals/MessageModal";
 import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
+import SpotModal from "../Elements/Modals/SpotModal";
 
 export const CreateSpotLayout = () => {
   const { currentUser } = useFirebaseAuth();
   const [ latLng, setLatLng ] = useState({});
   const [ open, setOpen ] = useState(true);
+  const [ createdSpot, setCreatedSpot ] = useState();
 
   const handleMapClick = (e) => {
     const lat = parseFloat(e.detail.latLng.lat);
@@ -45,6 +47,16 @@ export const CreateSpotLayout = () => {
 
   return (
     <Box sx={{display: "flex", flexDirection: "row", height: "100%"}} >
+      {createdSpot && createdSpot !== null &&
+        <SpotModal
+          open={open}
+          setOpen={setOpen}
+          title={createdSpot.title}
+          body={createdSpot.body}
+          icon={createdSpot.url}
+          // button={"login"}
+        />
+      }
       <Box sx={{height: "100%", width :"75%"}} >
         <MapView latLng={latLng} setLatLng={setLatLng} onClick={handleMapClick} >
           {latLng &&
@@ -53,7 +65,7 @@ export const CreateSpotLayout = () => {
         </MapView>
       </Box>
       <Box sx={{height: "100%", width :"25%"}}>
-        <CreateSpot latLng={latLng}/>
+        <CreateSpot latLng={latLng} setOpen={setOpen} setCreatedSpot={setCreatedSpot} />
       </Box>
     </Box>
   )

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -1,0 +1,13 @@
+import { Box, Button, Typography } from "@mui/material"
+
+export const HeroLayout = () => {
+  return (
+    <Box sx={{height: "100%", display: "flex", alignItems: "center"}} bgcolor={"black"} >
+      <Box >
+        <Typography variant="h1" color={"white"} sx={{mx: 5, mb: 1}} >BackHacker.</Typography>
+        <Typography variant="h4" color={"white"} sx={{mx: 5, mb: 7}} >ひらけPC。いくぞ世界。</Typography>
+        <Button variant="contained" color="primary" sx={{mx: 6, mb: 3}} >旅を始める</Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -1,12 +1,17 @@
 import { Box, Button, Typography } from "@mui/material"
+import { useNavigate } from "react-router-dom"
 
 export const HeroLayout = () => {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate("/map");
+  }
   return (
     <Box sx={{height: "100%", display: "flex", alignItems: "center"}} bgcolor={"black"} >
-      <Box >
-        <Typography variant="h1" color={"white"} sx={{mx: 5, mb: 1}} >BackHacker.</Typography>
-        <Typography variant="h4" color={"white"} sx={{mx: 5, mb: 7}} >ひらけPC。いくぞ世界。</Typography>
-        <Button variant="contained" color="primary" sx={{mx: 6, mb: 3}} >旅を始める</Button>
+      <Box sx={{mx: 20}} >
+        <Typography variant="h1" color={"white"} sx={{mb: 1}} >BackHacker.</Typography>
+        <Typography variant="h4" color={"white"} sx={{mb: 7}} >ひらけPC。いくぞ世界。</Typography>
+        <Button onClick={handleClick} variant="contained" color="primary" sx={{mx: 1, mb: 3}} >旅を始める</Button>
       </Box>
     </Box>
   )

--- a/src/features/spots/api/createSpot.js
+++ b/src/features/spots/api/createSpot.js
@@ -29,7 +29,7 @@ export const createSpot = async (
 
   try {
     const res = await axios.post("/api/v1/spots", data, config);
-    return res.data;
+    return res;
   } catch (err) {
     let message;
     if (axios.isAxiosError(err) && err.response) {

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -36,6 +36,8 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
         body: res.data.spot.name,
         url: res.data.videos[0].snippet.thumbnails.medium.url
       });
+      setSpotName("");
+      setSpotDescription("");
     }
   }
 
@@ -53,6 +55,7 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
           helperText="※必須項目です"
           placeholder="表示されるスポット名"
           name="spotName"
+          value={spotName}
           onChange={(e) => setSpotName(e.target.value)}
         />
         <TextField
@@ -65,6 +68,7 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
           placeholder="思い出や感想を入力してください"
           margin="normal"
           name='description'
+          value={spotDescription}
           onChange={(e) => setSpotDescription(e.target.value)}
         />
         <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -27,6 +27,7 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
     e.preventDefault();
     const address = await ReverseGeocode(latLng);
     const res = await createSpot(currentUser, spotName, spotDescription, latLng, address);
+    console.log(res.data)
     if (res.statusText === "Created") {
       setIsSuccessMessage(true);
       setMessage("登録が完了しました");
@@ -34,7 +35,8 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
       setCreatedSpot({
         title: "新規投稿が完了しました🎉",
         body: res.data.spot.name,
-        url: res.data.videos[0].snippet.thumbnails.medium.url
+        url: res.data.videos[0].snippet.thumbnails.medium.url,
+        id: res.data.spot.id
       });
       setSpotName("");
       setSpotDescription("");

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -5,6 +5,7 @@ import { createSpot } from "../api/createSpot";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Switch from '@mui/material/Switch';
 import { ReverseGeocode } from "./ReverseGeocode";
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 
 const style = {
   display: 'flex',
@@ -12,10 +13,12 @@ const style = {
   width: '90%',
   textAlign: 'center'
 }
-export const CreateSpot = ({ latLng }) => {
+
+export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
+  const { currentUser } = useFirebaseAuth();
+  const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ spotName, setSpotName ] = useState();
   const [ spotDescription, setSpotDescription ] = useState("");
-  const { currentUser } = useFirebaseAuth();
   const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
 
   const label = { inputProps: { 'aria-label': 'Switch demo' } };
@@ -23,7 +26,17 @@ export const CreateSpot = ({ latLng }) => {
   const handleSpotPost = async (e) => {
     e.preventDefault();
     const address = await ReverseGeocode(latLng);
-    await createSpot(currentUser, spotName, spotDescription, latLng, address);
+    const res = await createSpot(currentUser, spotName, spotDescription, latLng, address);
+    if (res.statusText === "Created") {
+      setIsSuccessMessage(true);
+      setMessage("登録が完了しました");
+      setOpen(true);
+      setCreatedSpot({
+        title: "新規投稿が完了しました🎉",
+        body: res.data.spot.name,
+        url: res.data.videos[0].snippet.thumbnails.medium.url
+      });
+    }
   }
 
   return (

--- a/src/features/spots/components/SpotCard.jsx
+++ b/src/features/spots/components/SpotCard.jsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { Link } from "react-router-dom";
 import Spinner from "../../../components/Elements/Spinner/Spinner";
 
-export const SpotCard = ({ spots }) => {
+export const SpotCard = ({ spots, text }) => {
 
   if (!spots) {
     return <div><Spinner /></div>
@@ -25,7 +25,7 @@ export const SpotCard = ({ spots }) => {
           </Box>
         ))
       ) : (
-        <Typography >投稿したスポットはありません</Typography>
+        <Typography >{text}したスポットはありません</Typography>
       )}
     </>
   )

--- a/src/features/users/components/SpotListTab.jsx
+++ b/src/features/users/components/SpotListTab.jsx
@@ -7,6 +7,8 @@ import Box from '@mui/material/Box';
 import { SpotCard } from '../../spots/components/SpotCard';
 import { useSpotsContext } from '../../../contexts/SpotsContext';
 import Spinner from '../../../components/Elements/Spinner/Spinner';
+import { Link } from 'react-router-dom';
+import { Button } from '@mui/material';
 
 function CustomTabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -94,6 +96,7 @@ export const SpotListTab = ({ userInfo }) => {
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
       {!spots && <Spinner ></Spinner>}
+      <Link to={`/users/${userInfo.id}/likes`}><Button variant='outlined' >地図上に表示</Button></Link>
         <Box
           display={"flex"}
           flexDirection={"column"}

--- a/src/features/users/components/SpotListTab.jsx
+++ b/src/features/users/components/SpotListTab.jsx
@@ -82,18 +82,25 @@ export const SpotListTab = ({ userInfo }) => {
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
+        {!spots && <Spinner ></Spinner>}
         <Box
           display={"flex"}
           flexDirection={"column"}
           justifyContent={'space-between'}
           alignItems={"center"}
         >
-          {spots ? <SpotCard spots={userPostedSpots()} /> : <Typography >投稿したスポットはありません</Typography>}
+          <SpotCard spots={userPostedSpots()} text={"投稿"} />
         </Box>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
-        <Box>
-          {spots ? <SpotCard spots={userLikedSpots()} /> : <Typography >いいねしたスポットはありません</Typography>}
+      {!spots && <Spinner ></Spinner>}
+        <Box
+          display={"flex"}
+          flexDirection={"column"}
+          justifyContent={'space-between'}
+          alignItems={"center"}
+        >
+          <SpotCard spots={userLikedSpots()} text={"いいね"} />
         </Box>
       </CustomTabPanel>
     </Box>

--- a/src/features/users/components/UserProfile.jsx
+++ b/src/features/users/components/UserProfile.jsx
@@ -5,19 +5,27 @@ import { WithdrawalButton } from "./WithdrawalButton";
 import { LogOutButton } from "../../auth/components/LogOutButton";
 
 export const UserProfile = ({ userInfo }) => {
-  const { loading } = useFirebaseAuth();
+  const { loading, userId } = useFirebaseAuth();
 
   if (loading) {
     return <div><Spinner /></div>;
   }
+
+  console.log(userInfo)
+  console.log(userId)
+
 
   return (
     userInfo && (
       <>
         <Typography >{userInfo.name}</Typography>
         <Avatar src={userInfo.avatar} sx={{mr: 3, width: 56, height: 56}}></Avatar>
-        <LogOutButton />
-        <WithdrawalButton />
+        {userId === userInfo.id &&
+          <>
+            <LogOutButton />
+            <WithdrawalButton />
+          </>
+        }
       </>
     )
   )

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -4,11 +4,13 @@ import { CreateSpotLayout } from '../components/Layout/CreateSpotLayout';
 import { IndexSpotLayout } from '../components/Layout/IndexSpotLayout';
 import { UserLayout } from '../components/Layout/UserLayout';
 import { IndexLikedSpotLayout } from '../components/Layout/IndexLikedSpotLayout';
+import { HeroLayout } from '../components/Layout/HeroLayout';
 
 export const AppRoutes = () => {
   return (
     <Routes>
-      <Route path="/" element={<MainLayout />}>
+      <Route element={<MainLayout />} >
+        <Route path="/" element={<HeroLayout />} />
         <Route path="/spots" element={<CreateSpotLayout />} />
         <Route path="/map" element={<IndexSpotLayout />} />
         <Route path="spots/:spotId" element={<IndexSpotLayout />} />


### PR DESCRIPTION
## 概要
- トップページを作成しました
- ヘッダーにトップページへのリンクを作成しました
- 各機能が動作した後に、特定の他の画面に遷移するようにしました

## 実施したこと
- [x] トップページの作成
  - [x] トップページに投稿一覧へのリンクを作成
[動画(トップ画面〜スポット一覧画面)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/33eaa120-5416-4b0c-91c7-c50ba0f161e4)

- [x] ヘッダーにトップページへのリンクを追加
- [x] プロフィール画面にリンクを追加
  - [x] ログイン、退会ボタンへのリンクを修正(ログイン中ユーザーのマイページのみ表示)

  | ログイン中のユーザーのマイページ  | ログイン中のユーザー以外のマイページ |
  | :---: | :---: |
  | <img width="239" alt="01dc1a9aeda9b822079bafacfa54f125" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/256472d6-c25a-4c49-b0f8-b8582005a19d"> | <img width="267" alt="4b3502af2375d18e9f4d0dc08f585f9c" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f0000dc2-5f36-4bcb-ad7b-ad505ccb41de"> |

  - [x] いいねしたスポット一覧(地図上に表示)へのリンクを作成
[動画(地図上に表示)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/6b0771c0-c113-4f1c-bcc9-a39a917cb077)
- [x] 新規投稿完了後の画面遷移を作成
  - [x] 新規投稿完了後に表示するモーダルを作成  
  [動画(投稿後モーダル表示)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/255f4ed9-25f6-4f7c-b78c-5053bf281ad3)

  - [x] モーダルに「投稿を確認する」リンクを作成  
  [動画(投稿を確認する)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f1ef6b8f-bdc8-4429-9994-2274fa89a2fb)

  - [x] モーダルに「投稿をシェアする」リンクを作成
  [動画(Xシェアボタン)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/24033c4a-1c8e-45aa-a56b-5d1253526d9b)

  - [x] モーダルに「続けて投稿する」リンクを作成
  [動画(続けて投稿するボタン)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/0a5cc247-cb95-4741-bdc7-125ed0e6198c)