### PR TITLE
スポット新規投稿機能の修正

### DIFF
--- a/src/components/Elements/Buttons/FloatingButton.jsx
+++ b/src/components/Elements/Buttons/FloatingButton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Fab from '@mui/material/Fab';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+
+export default function FloatingButton({ text, onClick }) {
+  return (
+    <Box sx={{ '& > :not(style)': { m: 1 } }} onClick={onClick} >
+      <Fab variant="extended" color="info">
+        {text}
+        <AddCircleIcon sx={{ ml: 1 }} />
+      </Fab>
+    </Box>
+  );
+}

--- a/src/components/Elements/Buttons/FloatingButton.jsx
+++ b/src/components/Elements/Buttons/FloatingButton.jsx
@@ -5,8 +5,8 @@ import AddCircleIcon from '@mui/icons-material/AddCircle';
 
 export default function FloatingButton({ text, onClick }) {
   return (
-    <Box sx={{ '& > :not(style)': { m: 1 } }} onClick={onClick} >
-      <Fab variant="extended" color="info">
+    <Box sx={{ '& > :not(style)': { m: 1 }, position: 'fixed', bottom: 16, left: '50%', transform: 'translateX(-50%)' }} onClick={onClick} >
+      <Fab variant="extended" color="secondary">
         {text}
         <AddCircleIcon sx={{ ml: 1 }} />
       </Fab>

--- a/src/components/Elements/Modals/MessageModal.jsx
+++ b/src/components/Elements/Modals/MessageModal.jsx
@@ -3,8 +3,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Modal from '@mui/material/Modal';
-import CloseIcon from '@mui/icons-material/Close';
-import { IconButton } from '@mui/material';
+import ReplayIcon from '@mui/icons-material/Replay';
 import { SignInButton } from '../../../features/auth/components/SignInButton';
 
 const style = {
@@ -14,7 +13,6 @@ const style = {
   transform: 'translate(-50%, -50%)',
   width: 400,
   bgcolor: 'background.paper',
-  // border: '2px solid #000',
   boxShadow: 24,
   p: 4,
   textAlign: "center"
@@ -34,7 +32,6 @@ export default function MessageModal({open, setOpen, title, body, icon, button})
         aria-describedby="modal-modal-description"
       >
         <Box sx={style}>
-          {buttonType === "close" && <IconButton onClick={handleClose}><CloseIcon variant={"contained"} color={"info"} /></IconButton>}
           <Typography id="modal-modal-title" variant="h6" component="h2">
             {title}
           </Typography>
@@ -44,6 +41,7 @@ export default function MessageModal({open, setOpen, title, body, icon, button})
           <Typography sx={{pt: 2}}>{body}</Typography>
           <Box sx={{pt: 2}} textAlign={"center"}>
             {buttonType === "login" && <SignInButton text={"ログイン"} variant={"contained"} color={"info"} />}
+            {buttonType === "close" && <Button variant="contained" color="info" onClick={handleClose}><ReplayIcon />別の場所を投稿する</Button>}
           </Box>
         </Box>
       </Modal>

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -9,7 +9,7 @@ import SpotModal from "../Elements/Modals/SpotModal";
 
 export const CreateSpotLayout = () => {
   const { currentUser, loading } = useFirebaseAuth();
-  const [ latLng, setLatLng ] = useState({});
+  const [ latLng, setLatLng ] = useState();
   const [ open, setOpen ] = useState(true);
   const [ createdSpot, setCreatedSpot ] = useState();
 

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -25,13 +25,6 @@ export const CreateSpotLayout = () => {
     icon: "📺 👀"
   };
 
-  const searchFailureModal = {
-    title: "動画を取得できませんでした",
-    body: "山、砂漠、海などは避け、都市部をクリックして再度試してみてください 🙇‍♂️",
-    icon: "😭",
-    button: "close"
-  };
-
   if (loading) return;
 
   if (!currentUser) {

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -65,7 +65,7 @@ export const CreateSpotLayout = () => {
         </MapView>
       </Box>
       <Box sx={{height: "100%", width :"25%"}}>
-        <CreateSpot latLng={latLng} setOpen={setOpen} setCreatedSpot={setCreatedSpot} />
+        <CreateSpot latLng={latLng} setLatLng={setLatLng} setOpen={setOpen} setCreatedSpot={setCreatedSpot} />
       </Box>
     </Box>
   )

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -8,7 +8,7 @@ import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 import SpotModal from "../Elements/Modals/SpotModal";
 
 export const CreateSpotLayout = () => {
-  const { currentUser } = useFirebaseAuth();
+  const { currentUser, loading } = useFirebaseAuth();
   const [ latLng, setLatLng ] = useState({});
   const [ open, setOpen ] = useState(true);
   const [ createdSpot, setCreatedSpot ] = useState();
@@ -31,6 +31,8 @@ export const CreateSpotLayout = () => {
     icon: "😭",
     button: "close"
   };
+
+  if (loading) return;
 
   if (!currentUser) {
     return (

--- a/src/components/Layout/IndexSpotLayout.jsx
+++ b/src/components/Layout/IndexSpotLayout.jsx
@@ -6,13 +6,23 @@ import { useState } from "react";
 import SpotDetailModal from "../Elements/Modals/SpotDetailModal";
 import { useLocation } from "react-router-dom";
 import FloatingButton from "../Elements/Buttons/FloatingButton";
+import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
+import MessageModal from "../Elements/Modals/MessageModal";
 
 export const IndexSpotLayout = () => {
+  const { currentUser, loading } = useFirebaseAuth();
   const { spotId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
   const [ clickedMarkerId, setClickedMarkerId ] = useState(location.state?.spotId ?? false);
   const [ open, setOpen ] = useState(location.state?.open ?? false);
+  const [ loginModalOpen, setLoginModalOpen ] = useState(false);
+
+  const createSpotModalMessage = {
+    title: "ログインするとスポット投稿できます",
+    body: "街の様子を動画で楽しもう！",
+    icon: "📺 👀"
+  };
 
   const handleMarkerClick = (spotId) => {
     setClickedMarkerId(spotId);
@@ -21,7 +31,13 @@ export const IndexSpotLayout = () => {
   }
 
   const handleButtonClick = () => {
-    navigate("/spots");
+    if (loading) return;
+
+    if (!currentUser) {
+      setLoginModalOpen(true);
+    } else {
+      navigate("/spots");
+    }
   }
 
   return (
@@ -34,6 +50,14 @@ export const IndexSpotLayout = () => {
           />
           <SpotDetailModal spotId={spotId} open={open} setOpen={setOpen} />
           <FloatingButton text={"新規投稿"} onClick={handleButtonClick} />
+          <MessageModal
+            open={loginModalOpen}
+            setOpen={setLoginModalOpen}
+            title={createSpotModalMessage.title}
+            body={createSpotModalMessage.body}
+            icon={createSpotModalMessage.icon}
+            button={"login"}
+          />
         </MapView>
       </Box>
     </Box>

--- a/src/components/Layout/IndexSpotLayout.jsx
+++ b/src/components/Layout/IndexSpotLayout.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useState } from "react";
 import SpotDetailModal from "../Elements/Modals/SpotDetailModal";
 import { useLocation } from "react-router-dom";
+import FloatingButton from "../Elements/Buttons/FloatingButton";
 
 export const IndexSpotLayout = () => {
   const { spotId } = useParams();
@@ -19,6 +20,10 @@ export const IndexSpotLayout = () => {
     navigate(`/spots/${spotId}`);
   }
 
+  const handleButtonClick = () => {
+    navigate("/spots");
+  }
+
   return (
     <Box sx={{display: "flex", flexDirection: "row", height: "100%"}} >
       <Box sx={{height: "100%", width :"100%"}} >
@@ -28,6 +33,7 @@ export const IndexSpotLayout = () => {
             clickedMarkerId={clickedMarkerId}
           />
           <SpotDetailModal spotId={spotId} open={open} setOpen={setOpen} />
+          <FloatingButton text={"新規投稿"} onClick={handleButtonClick} />
         </MapView>
       </Box>
     </Box>

--- a/src/features/likes/api/createLike.js
+++ b/src/features/likes/api/createLike.js
@@ -19,7 +19,6 @@ export const createLike = async (currentUser, selectedSpot) => {
 
   try {
     const res = await axios.post("/api/v1/likes", data, config);
-    console.log(res.data)
     return res.data;
   } catch (err) {
     let message;

--- a/src/features/likes/api/deleteLike.js
+++ b/src/features/likes/api/deleteLike.js
@@ -16,7 +16,6 @@ export const deleteLike = async (currentUser, id) => {
 
   try {
     const res = await axios.delete(`/api/v1/likes/${id}`, config);
-    console.log(res.data)
     return res.data;
   } catch (err) {
     let message;

--- a/src/features/spots/api/createSpot.js
+++ b/src/features/spots/api/createSpot.js
@@ -29,14 +29,19 @@ export const createSpot = async (
 
   try {
     const res = await axios.post("/api/v1/spots", data, config);
-    return res;
-  } catch (err) {
-    let message;
-    if (axios.isAxiosError(err) && err.response) {
-      console.error(err.response.data.message);
+
+    if (res.status === 201) {
+      // 成功時はレスポンスデータ全体を返す
+      return { success: true, data: res.data };
     } else {
-      message = String(err);
-      console.error(message);
+      // ステータスコードが201以外の場合は、エラーメッセージを返す
+      throw new Error("スポットの投稿に失敗しました");
+    }
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response) {
+      return { success: false, message: err.response.data.message || "エラーが発生しました" };
+    } else {
+      return { success: false, message: String(err) };
     }
   }
 }

--- a/src/features/spots/api/createSpot.js
+++ b/src/features/spots/api/createSpot.js
@@ -1,4 +1,5 @@
 import { axios } from "../../../lib/axios";
+import { isAxiosError } from 'axios';
 
 export const createSpot = async (
     currentUser,
@@ -38,7 +39,7 @@ export const createSpot = async (
       throw new Error("スポットの投稿に失敗しました");
     }
   } catch (err) {
-    if (axios.isAxiosError(err) && err.response) {
+    if (isAxiosError(err) && err.response) {
       return { success: false, message: err.response.data.message || "エラーが発生しました" };
     } else {
       return { success: false, message: String(err) };

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -1,5 +1,5 @@
-import { Box, Button, TextField, Typography } from "@mui/material"
-import { useState } from "react"
+import { Alert, Box, Button, TextField, Typography } from "@mui/material"
+import { useEffect, useState } from "react"
 import RoomTwoToneIcon from '@mui/icons-material/RoomTwoTone';
 import { createSpot } from "../api/createSpot";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
@@ -10,8 +10,12 @@ import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 const style = {
   display: 'flex',
   flexDirection: 'column',
+  height: "100%",
   width: '90%',
-  textAlign: 'center'
+  textAlign: 'center',
+  alignItems: "center",
+  margin: "0 auto",
+  paddingTop: "30px"
 }
 
 export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
@@ -20,8 +24,15 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
   const [ spotName, setSpotName ] = useState();
   const [ spotDescription, setSpotDescription ] = useState("");
   const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
+  const [ isDisabled, setIsDisabled] = useState(true);
 
   const label = { inputProps: { 'aria-label': 'Switch demo' } };
+
+  useEffect(() => {
+    if (latLng) {
+      setIsDisabled(false);
+    }
+  }, [latLng])
 
   const handleSpotPost = async (e) => {
     e.preventDefault();
@@ -38,15 +49,22 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
         url: res.data.videos[0].snippet.thumbnails.medium.url,
         id: res.data.spot.id
       });
-      setSpotName("");
-      setSpotDescription("");
+      handleCancelClick();
     }
   }
 
+  const handleCancelClick = () => {
+    setSpotName("");
+    setSpotDescription("");
+  }
+
   return (
-    <form onSubmit={handleSpotPost} >
+    latLng ?
       <Box style={style} >
-        <Typography variant='h5' fontSize={"24px"}><RoomTwoToneIcon />スポット新規投稿</Typography>
+    <form onSubmit={handleSpotPost} >
+        <Typography variant='h5' fontSize={"24px"}>
+          <RoomTwoToneIcon />スポット新規投稿
+        </Typography>
         <TextField
           id="spotName"
           label="スポット名"
@@ -57,6 +75,7 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
           helperText="※必須項目です"
           placeholder="表示されるスポット名"
           name="spotName"
+          disabled={isDisabled}
           value={spotName}
           onChange={(e) => setSpotName(e.target.value)}
         />
@@ -70,6 +89,7 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
           placeholder="思い出や感想を入力してください"
           margin="normal"
           name='description'
+          disabled={isDisabled}
           value={spotDescription}
           onChange={(e) => setSpotDescription(e.target.value)}
         />
@@ -86,8 +106,8 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
         <Box sx={{pb: 3}}>
           {isAutoFetchEnabled ? (
             <>
-              <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
-              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography>
+              {/* <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
+              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography> */}
             </>
           ) : (
             <>
@@ -97,18 +117,28 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
           )}
         </Box>
         <Box >
-          <Button variant='text' >キャンセル</Button>
-          <Button
-            type='submit'
-            color='success'
-            variant='contained'
-            display={"flex"}
-            sx={{width: "150px"}}
-          >
-            投稿する
-          </Button>
+          <>
+            <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
+            <Button
+              type='submit'
+              color='success'
+              variant='contained'
+              display={"flex"}
+              sx={{width: "150px"}}
+            >
+              投稿する
+            </Button>
+          </>
+
         </Box>
-      </Box>
     </form>
+      </Box>
+    :
+      <Box style={style} >
+        <Typography variant='h5' fontSize={"24px"}>
+          <RoomTwoToneIcon />スポット新規投稿
+        </Typography>
+        <Alert severity="info" variant="filled" sx={{mt: 5}}>地図上をクリックして、投稿する地点を指定してください</Alert>
+      </Box>
   )
 }

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -6,6 +6,7 @@ import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import Switch from '@mui/material/Switch';
 import { ReverseGeocode } from "./ReverseGeocode";
 import { useFlashMessage } from "../../../contexts/FlashMessageContext";
+import MessageModal from "../../../components/Elements/Modals/MessageModal";
 
 const style = {
   display: 'flex',
@@ -17,6 +18,12 @@ const style = {
   margin: "0 auto",
   paddingTop: "30px"
 }
+const searchFailureModal = {
+  title: "動画が見つかりませんでした...",
+  body: "山、砂漠、海などは避け、都市部をクリックして再度試してみてください",
+  icon: "😭",
+  button: "close"
+};
 
 export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
   const { currentUser } = useFirebaseAuth();
@@ -25,6 +32,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
   const [ spotDescription, setSpotDescription ] = useState("");
   const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
   const [ isDisabled, setIsDisabled] = useState(true);
+  const [ searchFailureModalOpen, setSearchFailureModalOpen ] = useState(false);
 
   const label = { inputProps: { 'aria-label': 'Switch demo' } };
 
@@ -38,6 +46,14 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
     e.preventDefault();
     setIsDisabled(true);
     const address = await ReverseGeocode(latLng);
+
+    if (address.address_components.length <= 1) {
+      setMessage("投稿に失敗しました");
+      setSearchFailureModalOpen(true);
+      return;
+    }
+
+    setSearchFailureModalOpen(false);
     const result = await createSpot(currentUser, spotName, spotDescription, latLng, address);
     if (result.success) {
       setIsSuccessMessage(true);
@@ -65,78 +81,85 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
   return (
     latLng ?
       <Box style={style} >
-    <form onSubmit={handleSpotPost} >
-        <Typography variant='h5' fontSize={"24px"}>
-          <RoomTwoToneIcon />スポット新規投稿
-        </Typography>
-        <TextField
-          id="spotName"
-          label="スポット名"
-          fullWidth
-          variant="outlined"
-          color="info"
-          margin="normal"
-          helperText="※必須項目です"
-          placeholder="表示されるスポット名"
-          name="spotName"
-          disabled={isDisabled}
-          value={spotName}
-          onChange={(e) => setSpotName(e.target.value)}
+        <MessageModal
+          open={searchFailureModalOpen}
+          setOpen={setSearchFailureModalOpen}
+          title={searchFailureModal.title}
+          body={searchFailureModal.body}
+          icon={searchFailureModal.icon}
+          button={"close"}
         />
-        <TextField
-          id="outlined-multiline-static"
-          label="説明"
-          fullWidth
-          multiline
-          rows={2}
-          color='info'
-          placeholder="思い出や感想を入力してください"
-          margin="normal"
-          name='description'
-          disabled={isDisabled}
-          value={spotDescription}
-          onChange={(e) => setSpotDescription(e.target.value)}
-        />
-        <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>
-          <Typography>動画を自動で取得する</Typography>
-          <Switch
-            {...label}
-            defaultChecked
-            disabled
-            checked={isAutoFetchEnabled}
-            onChange={() => setIsAutoFetchEnabled(!isAutoFetchEnabled)}
+        <form onSubmit={handleSpotPost} >
+          <Typography variant='h5' fontSize={"24px"}>
+            <RoomTwoToneIcon />スポット新規投稿
+          </Typography>
+          <TextField
+            id="spotName"
+            label="スポット名"
+            fullWidth
+            variant="outlined"
+            color="info"
+            margin="normal"
+            helperText="※必須項目です"
+            placeholder="表示されるスポット名"
+            name="spotName"
+            disabled={isDisabled}
+            value={spotName}
+            onChange={(e) => setSpotName(e.target.value)}
           />
-        </Box>
-        <Box sx={{pb: 3}}>
-          {isAutoFetchEnabled ? (
+          <TextField
+            id="outlined-multiline-static"
+            label="説明"
+            fullWidth
+            multiline
+            rows={2}
+            color='info'
+            placeholder="思い出や感想を入力してください"
+            margin="normal"
+            name='description'
+            disabled={isDisabled}
+            value={spotDescription}
+            onChange={(e) => setSpotDescription(e.target.value)}
+          />
+          <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>
+            <Typography>動画を自動で取得する</Typography>
+            <Switch
+              {...label}
+              defaultChecked
+              disabled
+              checked={isAutoFetchEnabled}
+              onChange={() => setIsAutoFetchEnabled(!isAutoFetchEnabled)}
+            />
+          </Box>
+          <Box sx={{pb: 3}}>
+            {isAutoFetchEnabled ? (
+              <>
+                {/* <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
+                <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography> */}
+              </>
+            ) : (
+              <>
+                <TextField label="YouTube動画URLを入力" ></TextField>
+                <Typography >https://www.youtube.com/</Typography>
+              </>
+            )}
+          </Box>
+          <Box >
             <>
-              {/* <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
-              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography> */}
+              <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
+              <Button
+                type='submit'
+                color='success'
+                variant='contained'
+                display={"flex"}
+                sx={{width: "150px"}}
+                disabled={isDisabled}
+              >
+                投稿する
+              </Button>
             </>
-          ) : (
-            <>
-              <TextField label="YouTube動画URLを入力" ></TextField>
-              <Typography >https://www.youtube.com/</Typography>
-            </>
-          )}
-        </Box>
-        <Box >
-          <>
-            <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
-            <Button
-              type='submit'
-              color='success'
-              variant='contained'
-              display={"flex"}
-              sx={{width: "150px"}}
-              disabled={isDisabled}
-            >
-              投稿する
-            </Button>
-          </>
-
-        </Box>
-    </form>
+          </Box>
+        </form>
       </Box>
     :
       <Box style={style} >

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -18,7 +18,7 @@ const style = {
   paddingTop: "30px"
 }
 
-export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
+export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
   const { currentUser } = useFirebaseAuth();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ spotName, setSpotName ] = useState();
@@ -56,6 +56,7 @@ export const CreateSpot = ({ latLng, setOpen, setCreatedSpot }) => {
   const handleCancelClick = () => {
     setSpotName("");
     setSpotDescription("");
+    setLatLng("");
   }
 
   return (

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -21,7 +21,7 @@ const style = {
 export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
   const { currentUser } = useFirebaseAuth();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
-  const [ spotName, setSpotName ] = useState();
+  const [ spotName, setSpotName ] = useState("");
   const [ spotDescription, setSpotDescription ] = useState("");
   const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
   const [ isDisabled, setIsDisabled] = useState(true);
@@ -36,20 +36,23 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
 
   const handleSpotPost = async (e) => {
     e.preventDefault();
+    setIsDisabled(true);
     const address = await ReverseGeocode(latLng);
-    const res = await createSpot(currentUser, spotName, spotDescription, latLng, address);
-    console.log(res);
-    if (res.statusText === "Created") {
+    const result = await createSpot(currentUser, spotName, spotDescription, latLng, address);
+    if (result.success) {
       setIsSuccessMessage(true);
       setMessage("登録が完了しました");
       setOpen(true);
+      setIsDisabled(false);
       setCreatedSpot({
         title: "新規投稿が完了しました🎉",
-        body: res.data.spot.name,
-        url: res.data.videos[0].snippet.thumbnails.medium.url,
-        id: res.data.spot.id
+        body: result.data.spot.name,
+        url: result.data.videos[0].snippet.thumbnails.medium.url,
+        id: result.data.spot.id
       });
       handleCancelClick();
+    } else {
+      setMessage(result.message);
     }
   }
 
@@ -126,6 +129,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
               variant='contained'
               display={"flex"}
               sx={{width: "150px"}}
+              disabled={isDisabled}
             >
               投稿する
             </Button>

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -10,8 +9,3 @@ root.render(
     <App />
   </React.StrictMode>
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();


### PR DESCRIPTION
## 概要
- 投稿一覧画面から新規スポット投稿画面へ遷移するボタンを追加しました。
- 新規スポット投稿機能のスタイルと不具合を修正しました。

## 実施したこと
- [x] スポット一覧画面に、新規投稿画面へのフローティングボタンを追加
[動画(新規投稿ボタン)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/639c36f9-b965-4382-94a2-64c2d5fade40)

- [x] 新規投稿フォームのスタイルを修正
[動画(地図をクリックした際にフォームを有効にする)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/de8acc46-b4b9-4c37-bcb4-dab070967fbb)
  - [x] 地図上をクリックするとフォームを有効にする
  - [x] レイアウトを中央寄せに修正
  - [x] 自動取得ボタンの表示を修正

- [x] 新規投稿画面にアクセスした時のローディングを追加(ログインを促すモーダルが一瞬だけ表示されていたので修正)
- [x] 住所が取得できない場合は新規投稿せず、モーダルを表示する機能を追加
[動画(住所が取得できない場合の投稿失敗モーダル)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/c7cad487-2a8a-47a0-97d0-d4186a6c48b8)

- [x] 投稿完了後のモーダルが表示されない不具合を修正