### PR TITLE
スポット削除機能の修正

### DIFF
--- a/src/components/Elements/Buttons/ConfigButton.jsx
+++ b/src/components/Elements/Buttons/ConfigButton.jsx
@@ -7,7 +7,7 @@ import { IconButton } from '@mui/material';
 import { DeleteButton } from './DeleteButton';
 import { EditButton } from './EditButton';
 
-export const ConfigButton = ({ currentUser, selectedSpot, setEditing }) => {
+export const ConfigButton = ({ currentUser, selectedSpot, setEditing, handleModalClose }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -43,7 +43,7 @@ export const ConfigButton = ({ currentUser, selectedSpot, setEditing }) => {
           <EditButton currentUser={currentUser} spot={selectedSpot} setEditing={setEditing} />
         </MenuItem>
         <MenuItem onClick={handleClose} >
-          <DeleteButton currentUser={currentUser} spot={selectedSpot} />
+          <DeleteButton currentUser={currentUser} spot={selectedSpot} handleClose={handleModalClose} />
         </MenuItem>
       </Menu>
     </div>

--- a/src/components/Elements/Buttons/DeleteButton.jsx
+++ b/src/components/Elements/Buttons/DeleteButton.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { useSpotsContext } from "../../../contexts/SpotsContext";
 import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 
-export const DeleteButton = ({ currentUser, spot }) => {
+export const DeleteButton = ({ currentUser, spot, handleClose }) => {
   const { loadSpots } = useSpotsContext();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const navigate = useNavigate();
@@ -15,7 +15,7 @@ export const DeleteButton = ({ currentUser, spot }) => {
       await deleteSpot(currentUser, spot.id, setIsSuccessMessage);
       await loadSpots();
       setMessage("削除しました");
-      navigate('/map');
+      handleClose();
     } catch (error) {
       setMessage(error.message);
       navigate('/map');

--- a/src/components/Elements/Modals/SpotDetailModal.jsx
+++ b/src/components/Elements/Modals/SpotDetailModal.jsx
@@ -26,7 +26,7 @@ export default function SpotDetailModal({ spotId, open, setOpen }) {
         open={open}
       >
         <DialogContent sx={{height: "100vh", p: 0, m: 0}}>
-          <SpotDetail spotId={spotId} selectedSpot={selectedSpot} setSelectedSpot={setSelectedSpot} handleVideoClick={handleVideoClick} />
+          <SpotDetail spotId={spotId} selectedSpot={selectedSpot} setSelectedSpot={setSelectedSpot} handleVideoClick={handleVideoClick} handleClose={handleClose} />
         </DialogContent>
       </Dialog>
       <VideoModal open={videoModalOpen} setOpen={setVideoModalOpen} selectedSpot={selectedSpot} />

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -9,7 +9,7 @@ import { ConfigButton } from "../../../components/Elements/Buttons/ConfigButton"
 import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
 import { ShareButton } from "../../../components/Elements/Buttons/ShareButton";
 
-export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoClick }) => {
+export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoClick, handleClose }) => {
   const { spots } = useSpotsContext();
   const { currentUser, userId } = useFirebaseAuth();
   const [ editing, setEditing ] = useState(false);
@@ -52,6 +52,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
               currentUser={currentUser}
               selectedSpot={selectedSpot}
               setEditing={setEditing}
+              handleModalClose={handleClose}
             />
           }
           </Box>

--- a/src/features/spots/components/SpotIndex.jsx
+++ b/src/features/spots/components/SpotIndex.jsx
@@ -32,7 +32,6 @@ export const SpotIndex = ({ handleMarkerClick, clickedMarkerId }) => {
             />
             {spot.id === clickedMarkerId &&
               <MyMarker
-                key={spot.id}
                 position={{
                   lat: spot.lat,
                   lng: spot.lng


### PR DESCRIPTION
## 概要
- スポット削除ボタンを押下後、モーダルが閉じない不具合を修正しました。
- スポット削除ボタン押下後、削除したスポットのピンが削除されない不具合を修正しました。

## 実施したこと
- [x] スポット削除後にモーダルが閉じられないバグを修正
  - [x] `SpotDetailModal`コンポーネントの`handleClose`関数(モーダルを閉じる処理)を、
  以下の流れで`DeleteButton`コンポーネントに`props`として渡しました。

- 流れ

    - `SpotDetailModal`コンポーネント (スポット詳細情報を表示するモーダル) ⤵︎
    - `SpotDetail`コンポーネント (スポット詳細情報をモーダル内部に表示する) ⤵︎
    - `ConfigButton`コンポーネント (スポット編集ボタンとスポット削除ボタンを表示するボタン) ⤵︎
    - `DeleteButton`コンポーネント (スポットを削除するボタン)

`handleClose`関数
```js
const handleClose = () => {
    setOpen(false);
    navigate("/map");
  };
```

- [x] スポット削除後にピンが削除されないバグを修正
  - [x] `MyMarker`(クリックされたスポットを表す青いピン)の`key`が重複していたため削除しました。

- 修正前
```js
// 選択されていないピン
<Marker
  key={spot.id}
  position={{
    lat: spot.lat,
    lng: spot.lng
  }}
  onClick={() => handleMarkerClick(spot.id)}
/>

// 選択されているピン
{spot.id === clickedMarkerId &&
  <MyMarker
    key={spot.id}  // 選択されていないピン(Marker)とkeyが重複している
    position={{
      lat: spot.lat,
      lng: spot.lng
    }}
    onClick={() => handleMarkerClick(spot.id)}
/>
```

- 修正後
```js
// 選択されていないピン
<Marker
  key={spot.id}
  position={{
    lat: spot.lat,
    lng: spot.lng
  }}
  onClick={() => handleMarkerClick(spot.id)}
/>

// 選択されているピン
{spot.id === clickedMarkerId &&
  <MyMarker // keyを削除
    position={{
      lat: spot.lat,
      lng: spot.lng
    }}
    onClick={() => handleMarkerClick(spot.id)}
/>
```

## 結果 
- 以下の動画の通り、スポット削除後にモーダルは閉じられ、ピンも削除されるようになりました。
![動画(スポット削除後のモーダル非表示)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/e552fcff-e2c8-47d6-81ae-d19dd7ca7a07)
 