### PR TITLE
画面遷移の修正

### DIFF
--- a/src/components/Elements/Modals/MessageModal.jsx
+++ b/src/components/Elements/Modals/MessageModal.jsx
@@ -40,7 +40,7 @@ export default function MessageModal({open, setOpen, title, body, icon, button})
           </Typography>
           <Typography sx={{pt: 2}}>{body}</Typography>
           <Box sx={{pt: 2}} textAlign={"center"}>
-            {buttonType === "login" && <SignInButton text={"ログイン"} variant={"contained"} color={"info"} />}
+            {buttonType === "login" && <SignInButton text={"ログイン"} variant={"contained"} color={"info"} handleClose={handleClose} />}
             {buttonType === "close" && <Button variant="contained" color="info" onClick={handleClose}><ReplayIcon />別の場所を投稿する</Button>}
           </Box>
         </Box>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -13,7 +13,7 @@ import { SignInButton } from '../../features/auth/components/SignInButton';
 import { useFirebaseAuth } from '../../hooks/useFirebaseAuth';
 import { Link, useNavigate } from "react-router-dom";
 import { Avatar } from '@mui/material';
-
+import HomeIcon from '@mui/icons-material/Home';
 
 export default function Header() {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -47,6 +47,11 @@ export default function Header() {
     navigate(`/users/${userId}`);
   }
 
+  const handleNavigate = () => {
+    handleMenuClose();
+    navigate("/");
+  }
+
   const menuId = 'primary-search-account-menu';
 
   // ヘッダー右側のアイコン部分
@@ -67,9 +72,14 @@ export default function Header() {
       onClose={handleMenuClose}
     >
       {currentUser && currentUser !== null &&
-        <MenuItem onClick={handleProfileOpen}>
-          <AccountCircle sx={{pr :1}}/>プロフィール
-        </MenuItem>
+        <>
+          <MenuItem onClick={handleProfileOpen}>
+            <AccountCircle sx={{pr :1}}/>マイページ
+          </MenuItem>
+          <MenuItem onClick={handleNavigate}>
+            <HomeIcon sx={{pr :1}}/>トップ
+          </MenuItem>
+        </>
       }
     </Menu>
   );
@@ -115,7 +125,16 @@ export default function Header() {
             >
               <AccountCircle />
             </IconButton>
-            <Typography >プロフィール</Typography>
+            <Typography >マイページ</Typography>
+          </MenuItem>
+          <MenuItem onClick={handleNavigate}>
+            <IconButton
+              size="large"
+              color="inherit"
+            >
+              <HomeIcon />
+            </IconButton>
+            <Typography >トップ</Typography>
           </MenuItem>
           </div>
       ) : (

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -131,7 +131,7 @@ export default function Header() {
       <AppBar position="static" sx={{pl: 5}}>
         <Toolbar>
           <Link
-              to={"/"}
+              to={`${currentUser ? "/map" : "/"}`}
               style={{color: "inherit", textDecoration: "none"}}
             >
             <Typography

--- a/src/features/auth/components/SignInButton.jsx
+++ b/src/features/auth/components/SignInButton.jsx
@@ -5,7 +5,7 @@ import { Button, Typography } from '@mui/material';
 import { Login } from '@mui/icons-material';
 import { useFlashMessage } from '../../../contexts/FlashMessageContext';
 
-export const SignInButton = ({ text, currentUser, variant, color }) => {
+export const SignInButton = ({ text, variant, color, handleClose }) => {
   const { loginWithGoogle } = useFirebaseAuth();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
 
@@ -28,6 +28,7 @@ export const SignInButton = ({ text, currentUser, variant, color }) => {
           // 成功時はレスポンスデータ全体を返す
           setIsSuccessMessage(true);
           setMessage("ログインしました");
+          handleClose();
           return { success: true, data: res.data };
         } else {
           // ステータスコードが200以外の場合は、エラーメッセージを返す

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -23,7 +23,6 @@ export const useFirebaseAuth = () => {
     if (result) {
       const user = result.user;
       setCurrentUser(user);
-      navigate("/");
       return user;
     }
   };


### PR DESCRIPTION
## 概要
- ログイン処理後の画面遷移と表示内容を修正しました。
- ヘッダーのロゴのリンク先と、ボタンの表示内容を変更しました。

## 実施したこと
- [x] ログイン処理後の動作を変更
  - [x] ログイン処理後にトップページに遷移しているので、その場でログインするように修正
  - [x] ログインを促すモーダルのログインボタンを押下してログインした後、モーダルを閉じるように修正
  - [x] ログイン完了時、「ログインしました」のフラッシュメッセージが表示されるように修正
  
[動画(いいねボタンからログイン時)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/e7a68328-f574-4859-a782-4b1431efacce)
[動画(新規投稿ボタンからのログイン時)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/794a8320-071c-446e-8f79-8471f18a45ae)

- [x] ヘッダーの修正
  - [x] ヘッダーのロゴのリンクの遷移先を変更
    - [x] ログインしている場合、スポット一覧画面に遷移する
    - [x] ログインしていない場合、トップページに遷移する
    
[動画(ログイン後ヘッダーをクリック)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/49d65050-8092-487f-be39-a30fbf88a83f)

  - [x] ログイン後ヘッダーに、トップページに遷移するリンクを追加

修正前
  <img width="244" alt="変更前プロフィール" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/a6caa975-c58c-48a5-8f15-74eb18f7c165">
  
  修正後
  <img width="245" alt="変更後プロフィール" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/638d6cdc-aa5d-468e-b0cd-4432dce3d534">


