### PR TITLE
スポット編集機能の修正

### DIFF
--- a/src/features/spots/components/EditSpot.jsx
+++ b/src/features/spots/components/EditSpot.jsx
@@ -11,9 +11,14 @@ import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 const style = {
   display: 'flex',
   flexDirection: 'column',
+  height: "100%",
   width: '90%',
-  textAlign: 'center'
+  textAlign: 'center',
+  alignItems: "center",
+  margin: "0 auto",
+  paddingTop: "30px"
 }
+
 export const EditSpot = ({ spot, setEditing, title }) => {
   const { currentUser } = useFirebaseAuth();
   const { loadSpots } = useSpotsContext();
@@ -88,8 +93,8 @@ export const EditSpot = ({ spot, setEditing, title }) => {
         <Box sx={{pb: 3}}>
           {isAutoFetchEnabled ? (
             <>
-              <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
-              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography>
+              {/* <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
+              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography> */}
             </>
           ) : (
             <>

--- a/src/features/spots/components/EditSpot.jsx
+++ b/src/features/spots/components/EditSpot.jsx
@@ -25,7 +25,6 @@ export const EditSpot = ({ spot, setEditing, title }) => {
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ spotName, setSpotName ] = useState();
   const [ spotDescription, setSpotDescription ] = useState("");
-  const [ isAutoFetchEnabled, setIsAutoFetchEnabled ] = useState(true);
 
   const label = { inputProps: { 'aria-label': 'Switch demo' } };
 
@@ -81,27 +80,7 @@ export const EditSpot = ({ spot, setEditing, title }) => {
           onChange={(e) => setSpotDescription(e.target.value)}
         />
         <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>
-          <Typography>動画を自動で取得する</Typography>
-          <Switch
-            {...label}
-            defaultChecked
-            disabled
-            checked={isAutoFetchEnabled}
-            onChange={() => setIsAutoFetchEnabled(!isAutoFetchEnabled)}
-          />
-        </Box>
-        <Box sx={{pb: 3}}>
-          {isAutoFetchEnabled ? (
-            <>
-              {/* <Typography fontSize={"14px"} >オススメ！ピンの周辺の動画を</Typography>
-              <Typography fontSize={"14px"} >自動で取得します(1回/日 限定)</Typography> */}
-            </>
-          ) : (
-            <>
-              <TextField label="YouTube動画URLを入力" ></TextField>
-              <Typography >https://www.youtube.com/</Typography>
-            </>
-          )}
+
         </Box>
         <Box >
           <Button variant='text' onClick={() => setEditing(false)} >キャンセル</Button>

--- a/src/features/spots/components/EditSpot.jsx
+++ b/src/features/spots/components/EditSpot.jsx
@@ -24,7 +24,7 @@ export const EditSpot = ({ spot, setEditing, title }) => {
   const { loadSpots } = useSpotsContext();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ spotName, setSpotName ] = useState();
-  const [ spotDescription, setSpotDescription ] = useState("");
+  const [ spotDescription, setSpotDescription ] = useState();
 
   const label = { inputProps: { 'aria-label': 'Switch demo' } };
 


### PR DESCRIPTION
## 概要
- スポット編集画面のレイアウトを修正しました。
- スポット編集時の不具合を修正しました。

## 実施したこと
- [x] スポット編集画面のレイアウトを中央寄せに修正
- [x] スポット編集画面の自動で動画を取得するボタンの表示を修正
  
修正前
<img width="569" alt="画像(スポット編集 修正前)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/3abeff60-85ad-437b-a576-b341da922b9b">

修正後
<img width="541" alt="画像(スポット編集 修正後)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/bfa611d1-5feb-4b55-9f24-fb0b5e08450f">

- [x] スポット編集をキャンセルした際、説明(`description`)が空になってしまう不具合を修正
  - `description`の入力値を保持するstateの初期値が空文字に設定されていたことが原因でしたので修正しました。

修正前
```js
  const [ spotDescription, setSpotDescription ] = useState("");
```  
  
  修正後
 ```js
  const [ spotDescription, setSpotDescription ] = useState();
```