### PR TITLE
レイアウトの修正

### DIFF
--- a/src/components/Elements/Buttons/LikeButton.jsx
+++ b/src/components/Elements/Buttons/LikeButton.jsx
@@ -78,7 +78,7 @@ export const LikeButton = ({ savedLikes, selectedSpot }) => {
       >
         <ClickedLikeIcon on={on}/>
       </IconButton>
-      {likedCount > 0 && <Typography color={"#d600a6"} fontWeight={"bold"} >{likedCount}</Typography> }
+      {likedCount > 0 && <Typography color={on ? "#d600a6" : "#979797"} fontWeight={"bold"} >{likedCount}</Typography> }
     </>
   )
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -12,7 +12,7 @@ import MoreIcon from '@mui/icons-material/MoreVert';
 import { SignInButton } from '../../features/auth/components/SignInButton';
 import { useFirebaseAuth } from '../../hooks/useFirebaseAuth';
 import { Link, useNavigate } from "react-router-dom";
-import { Avatar } from '@mui/material';
+import { Avatar, Tooltip } from '@mui/material';
 import HomeIcon from '@mui/icons-material/Home';
 
 export default function Header() {
@@ -104,15 +104,17 @@ export default function Header() {
       {currentUser && currentUser !== null ? (
         <div>
           <MenuItem>
-            <IconButton
-              size="large"
-              aria-label="show 17 new notifications"
-              color="inherit"
-            >
-              {/* <Badge badgeContent={17} color="error"> */}
-                <NotificationsIcon />
-              {/* </Badge> */}
-            </IconButton>
+            <Tooltip title="通知(作成中)" >
+              <IconButton
+                size="large"
+                aria-label="show 17 new notifications"
+                color="inherit"
+              >
+                {/* <Badge badgeContent={17} color="error"> */}
+                  <NotificationsIcon />
+                {/* </Badge> */}
+              </IconButton>
+            </Tooltip>
             <Typography >通知</Typography>
           </MenuItem>
           <MenuItem onClick={handleProfileOpen}>
@@ -170,15 +172,17 @@ export default function Header() {
               <>
                 {currentUser && currentUser !== null ? (
                   <>
-                    <IconButton
-                    size="large"
-                    aria-label="show 17 new notifications"
-                    color="inherit"
-                    >
-                    {/* <Badge badgeContent={17} color="error"> */}
-                      <NotificationsIcon />
-                    {/* </Badge> */}
-                    </IconButton>
+                    <Tooltip title="通知(作成中)" >
+                      <IconButton
+                      size="large"
+                      aria-label="show 17 new notifications"
+                      color="inherit"
+                      >
+                      {/* <Badge badgeContent={17} color="error"> */}
+                        <NotificationsIcon />
+                      {/* </Badge> */}
+                      </IconButton>
+                    </Tooltip>
                     <IconButton
                       size="large"
                       edge="end"

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -104,17 +104,20 @@ export default function Header() {
       {currentUser && currentUser !== null ? (
         <div>
           <MenuItem>
-            <Tooltip title="通知(作成中)" >
-              <IconButton
-                size="large"
-                aria-label="show 17 new notifications"
-                color="inherit"
-              >
-                {/* <Badge badgeContent={17} color="error"> */}
-                  <NotificationsIcon />
-                {/* </Badge> */}
-              </IconButton>
-            </Tooltip>
+            <span>
+              <Tooltip title="通知(作成中)" >
+                <IconButton
+                  size="large"
+                  aria-label="show 17 new notifications"
+                  color="inherit"
+                  disabled
+                >
+                  {/* <Badge badgeContent={17} color="error"> */}
+                    <NotificationsIcon />
+                  {/* </Badge> */}
+                </IconButton>
+              </Tooltip>
+            </span>
             <Typography >通知</Typography>
           </MenuItem>
           <MenuItem onClick={handleProfileOpen}>
@@ -173,15 +176,18 @@ export default function Header() {
                 {currentUser && currentUser !== null ? (
                   <>
                     <Tooltip title="通知(作成中)" >
-                      <IconButton
-                      size="large"
-                      aria-label="show 17 new notifications"
-                      color="inherit"
-                      >
-                      {/* <Badge badgeContent={17} color="error"> */}
-                        <NotificationsIcon />
-                      {/* </Badge> */}
-                      </IconButton>
+                      <span>
+                        <IconButton
+                          size="large"
+                          aria-label="show 17 new notifications"
+                          color="inherit"
+                          disabled
+                        >
+                        {/* <Badge badgeContent={17} color="error"> */}
+                          <NotificationsIcon />
+                        {/* </Badge> */}
+                        </IconButton>
+                      </span>
                     </Tooltip>
                     <IconButton
                       size="large"

--- a/src/features/spots/components/SpotCard.jsx
+++ b/src/features/spots/components/SpotCard.jsx
@@ -19,7 +19,15 @@ export const SpotCard = ({ spots, text }) => {
                 style={{color: "inherit", textDecoration: "none"}}
                 state={{ open: true, spotId: spot.id }}
               >
-                <Typography>{spot.name}</Typography>
+                <Typography
+                  sx={{
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {spot.name || "---"}
+                </Typography>
                 <img
                   src={spot.videos[0].thumbnail_url}
                   alt="動画のサムネイル"

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -56,10 +56,36 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
             />
           }
           </Box>
-          <Box >
+          <Box
+            sx={{
+              position: 'relative',
+              '&:hover': {
+                '& img': {
+                  filter: 'brightness(50%)',
+                },
+                '& .icon-overlay': {
+                  visibility: 'visible',
+                },
+              },
+            }}
+          >
             <Button onClick={handleVideoClick}>
-              <img src={selectedSpot.videos[0].thumbnail_url} />
+              <img src={selectedSpot.videos[0].thumbnail_url} alt="サムネイル" style={{ width: '100%', display: 'block' }} />
             </Button>
+            <Box
+              className="icon-overlay"
+              sx={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                visibility: 'hidden',
+              }}
+            >
+              <Button onClick={handleVideoClick} >
+                <Typography fontSize="20px" fontWeight="bold" color="white" >Watch Videos</Typography>
+              </Button>
+            </Box>
           </Box>
           <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%"}}>
             <Box sx={{display: "flex", justifyContent: "left", alignItems: "center", width: "100%"}}>

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -39,8 +39,15 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
               <Button
                 component={Link}
                 to={`/users/${selectedSpot.user.id}`}
-                style={{color: "inherit", textDecoration: "none", display: "flex", flexDirection: "row"}}
-                sx={{mb: 2}}
+                sx={{
+                  color: "inherit",
+                  textDecoration: "none",
+                  display: "flex",
+                  flexDirection: "row",
+                  justifyContent: "left",
+                  mb: 2,
+                  width: "100%"
+                }}
               >
                 <Avatar src={selectedSpot.user.avatar} sx={{mr: 2}} ></Avatar>
                 <Typography fontSize="20px" >{selectedSpot.user.name}</Typography>

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Button, IconButton, Typography } from "@mui/material"
+import { Avatar, Box, Button, IconButton, Tooltip, Typography } from "@mui/material"
 import { useSpotsContext } from "../../../contexts/SpotsContext"
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -63,7 +63,9 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
           </Box>
           <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%"}}>
             <Box sx={{display: "flex", justifyContent: "left", alignItems: "center", width: "100%"}}>
-              <IconButton disabled sx={{mx: 2}} ><ChatBubbleIcon color={"#c2c2c2"} /></IconButton>
+              <Tooltip title="コメントする(機能作成中)">
+                <IconButton sx={{mx: 2}} ><ChatBubbleIcon /></IconButton>
+              </Tooltip>
               <LikeButton
                 savedLikes={selectedSpot.likes}
                 selectedSpot={selectedSpot}

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -64,7 +64,9 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
           <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%"}}>
             <Box sx={{display: "flex", justifyContent: "left", alignItems: "center", width: "100%"}}>
               <Tooltip title="コメントする(機能作成中)">
-                <IconButton sx={{mx: 2}} ><ChatBubbleIcon /></IconButton>
+                <span>
+                  <IconButton sx={{mx: 2}} disabled ><ChatBubbleIcon /></IconButton>
+                </span>
               </Tooltip>
               <LikeButton
                 savedLikes={selectedSpot.likes}


### PR DESCRIPTION
## 概要
- レイアウトの修正を実施しました。
  - 機能していないボタンに対して、ホバー時に説明文を表示するようにしました。
  - 動画サムネイルにホバーした際、クリックしてビデオを視聴できる機能がわかりにくかったので
  ホバー時に案内文を表示するようにしました。
  - スポット名の文字数が多すぎる場合に、レイアウト崩れが発生していたので修正しました。
  - いいね数の文字色を変更しました。

## 実施したこと
- [x] スポット詳細の動画サムネイルのホバーアクションを追加
![動画(動画サムネイルにホバー時)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/613094f4-f7de-48ae-a699-eebc120d5b3d)

- [x] `SpotCard`で、スポット名の文字数が多い場合に発生するレイアウト崩れを修正
![画像(スポットカードの名前レイアウト修正)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f794409d-76cb-4bd4-8556-6d5a2695225a)

- [x] スポット詳細画面で、スポット名の文字数が多い場合に発生するレイアウト崩れを修正
[画像(スポット詳細修正前)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/07d0ffe0-935c-4817-ac76-b0e04d286b91)
[画像(スポット詳細修正後)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/bfed8ca0-ed18-4898-ae0b-0720459af6d7)

- [x] 通知ボタンのHoverを設定
![動画(通知ボタンのホバー)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/bd49a45c-0b77-48a7-bc77-e7e7e00b7de2)

- [x] コメントボタンのHoverを設定
![動画(コメントボタンのホバー)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/797ff8e0-9640-480b-95bd-90985d853597)

- [x] ログインしているユーザーがいいね済みでないスポットの場合、いいね数の色をグレーに修正
![動画(いいね数の色変更)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/ec97a3ec-c513-49d4-8ab9-4decce921cdd)
