### PR TITLE
地図の設定変更

### DIFF
--- a/src/components/Elements/Markers/MyMarker.jsx
+++ b/src/components/Elements/Markers/MyMarker.jsx
@@ -7,7 +7,7 @@ export const MyMarker = ({ key, position }) => {
         background={'#22ccff'}
         borderColor={'#1e89a1'}
         glyphColor={'#0f677a'}
-      >You</Pin>
+      >Now</Pin>
     </AdvancedMarker>
   )
 }

--- a/src/components/Elements/Markers/SpotMarker.jsx
+++ b/src/components/Elements/Markers/SpotMarker.jsx
@@ -1,0 +1,25 @@
+import { Avatar } from "@mui/material"
+import { AdvancedMarker, Pin } from "@vis.gl/react-google-maps"
+
+export const SpotMarker = ({ key, position, onClick, avatar }) => {
+  return (
+    <AdvancedMarker
+      key={key}
+      position={position}
+      onClick={onClick}
+    >
+      <Pin
+        // background={'#22ccff'}
+        // borderColor={'#1e89a1'}
+        // glyphColor={'#0f677a'}
+      >
+        {<Avatar
+          src={avatar}
+          sx={{ width: 24, height: 24 }}
+          alt={`${avatar}`}
+        >
+        </Avatar>}
+      </Pin>
+    </AdvancedMarker>
+  )
+}

--- a/src/components/Map/MapView.jsx
+++ b/src/components/Map/MapView.jsx
@@ -14,6 +14,8 @@ export const MapView = ({ children, onClick }) => {
         disableDefaultUI
         gestureHandling={'greedy'}
         onClick={onClick}
+        minZoom={2}
+        maxZoom={16}
       >
         {children}
       </Map>

--- a/src/features/spots/components/LikedSpotIndex.jsx
+++ b/src/features/spots/components/LikedSpotIndex.jsx
@@ -1,8 +1,8 @@
-import { Marker } from '@vis.gl/react-google-maps';
 import { useEffect } from 'react';
 import { useSpotsContext } from '../../../contexts/SpotsContext';
 import { useParams } from "react-router-dom";
 import { MyMarker } from '../../../components/Elements/Markers/MyMarker';
+import { SpotMarker } from '../../../components/Elements/Markers/SpotMarker';
 
 export const LikedSpotIndex = ({handleMarkerClick, isClickedMarkerId}) => {
   const { userId } = useParams();
@@ -24,12 +24,13 @@ export const LikedSpotIndex = ({handleMarkerClick, isClickedMarkerId}) => {
       {likedSpots ? (
         likedSpots.map((spot) =>
           <>
-            <Marker
+            <SpotMarker
               key={spot.id}
               position={{
                 lat: spot.lat,
                 lng: spot.lng
               }}
+              avatar={spot.user.avatar}
               // onClick={() => handleMarkerClick(spot.id)}
             />
             {spot.id === isClickedMarkerId &&

--- a/src/features/spots/components/SpotIndex.jsx
+++ b/src/features/spots/components/SpotIndex.jsx
@@ -1,7 +1,7 @@
-import { Marker } from '@vis.gl/react-google-maps';
 import { useEffect } from 'react';
 import { useSpotsContext } from '../../../contexts/SpotsContext';
 import { MyMarker } from '../../../components/Elements/Markers/MyMarker';
+import { SpotMarker } from '../../../components/Elements/Markers/SpotMarker';
 
 export const SpotIndex = ({ handleMarkerClick, clickedMarkerId }) => {
   const { spots, loadSpots } = useSpotsContext();
@@ -22,13 +22,14 @@ export const SpotIndex = ({ handleMarkerClick, clickedMarkerId }) => {
       {spots ? (
         spots.map((spot) =>
           <>
-            <Marker
+            <SpotMarker
               key={spot.id}
               position={{
                 lat: spot.lat,
                 lng: spot.lng
               }}
               onClick={() => handleMarkerClick(spot.id)}
+              avatar={spot.user.avatar}
             />
             {spot.id === clickedMarkerId &&
               <MyMarker


### PR DESCRIPTION
## 概要
- 地図の最大ズームおよび最小ズームの値を設定し、「実際にユーザーが利用すると想定される範囲」のみを表示するようにしました。
- マーカーの表示を変更し、それぞれのマーカーが何を表すのかをユーザーが分かるようにしました。

## 実施したこと
- [x] 地図の最大ズームと最小ズームを設定
- 変更前の最小ズーム<img width="1440" alt="画像(変更前の最小ズーム)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/6d9cecfd-7f4d-4da5-91ba-01bb3d66b78a">
- 変更後の最小ズーム<img width="1440" alt="画像(変更後の最小ズーム)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/03a0dae8-ce55-481a-80cd-6542d1357f81">

- [x] スポットを表すマーカーに`AdvancedMarker`を設定
  - [x] 投稿したユーザーのアバターが表示されるように変更 
- [x] 選択中のスポットのマーカーの表示を修正
  - [x] 文字を`You`から`Now`に変更(目的: 自分の投稿したスポットと誤認されないため) 
- 変更前
<img width="245" alt="画像(スポットと現在地のマーカー修正前)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f6f171e4-0a3a-42ba-bffc-06d6948be687">

- 変更後
<img width="187" alt="画像(スポットと現在地のマーカー修正後)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/0d857a88-39b9-4881-94d1-8b1f2371e371">
