### PR TITLE
スポット投稿機能の修正

### DIFF
--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -6,10 +6,13 @@ import { Marker } from '@vis.gl/react-google-maps';
 import MessageModal from "../Elements/Modals/MessageModal";
 import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 import SpotModal from "../Elements/Modals/SpotModal";
+import { useLocation } from 'react-router-dom';
+import { MyMarker } from "../Elements/Markers/MyMarker";
 
 export const CreateSpotLayout = () => {
   const { currentUser, loading } = useFirebaseAuth();
-  const [ latLng, setLatLng ] = useState();
+  const location = useLocation();
+  const [ latLng, setLatLng ] = useState(location.state?.latLng ?? null);
   const [ open, setOpen ] = useState(true);
   const [ createdSpot, setCreatedSpot ] = useState();
 
@@ -53,7 +56,7 @@ export const CreateSpotLayout = () => {
       <Box sx={{height: "100%", width :"75%"}} >
         <MapView onClick={handleMapClick} >
           {latLng &&
-            <Marker position={latLng} />
+            <MyMarker position={latLng} />
           }
         </MapView>
       </Box>

--- a/src/components/Layout/IndexSpotLayout.jsx
+++ b/src/components/Layout/IndexSpotLayout.jsx
@@ -46,7 +46,7 @@ export const IndexSpotLayout = () => {
     if (!currentUser) {
       setLoginModalOpen(true);
     } else {
-      navigate("/spots");
+      navigate("/spots", { state: { latLng: latLng } });
     }
   }
 

--- a/src/components/Layout/IndexSpotLayout.jsx
+++ b/src/components/Layout/IndexSpotLayout.jsx
@@ -8,6 +8,7 @@ import { useLocation } from "react-router-dom";
 import FloatingButton from "../Elements/Buttons/FloatingButton";
 import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 import MessageModal from "../Elements/Modals/MessageModal";
+import { MyMarker } from "../Elements/Markers/MyMarker";
 
 export const IndexSpotLayout = () => {
   const { currentUser, loading } = useFirebaseAuth();
@@ -17,6 +18,7 @@ export const IndexSpotLayout = () => {
   const [ clickedMarkerId, setClickedMarkerId ] = useState(location.state?.spotId ?? false);
   const [ open, setOpen ] = useState(location.state?.open ?? false);
   const [ loginModalOpen, setLoginModalOpen ] = useState(false);
+  const [ latLng, setLatLng ] = useState();
 
   const createSpotModalMessage = {
     title: "ログインするとスポット投稿できます",
@@ -27,7 +29,15 @@ export const IndexSpotLayout = () => {
   const handleMarkerClick = (spotId) => {
     setClickedMarkerId(spotId);
     setOpen(true);
+    setLatLng(null);
     navigate(`/spots/${spotId}`);
+  }
+
+  const handleMapClick = (e) => {
+    const lat = parseFloat(e.detail.latLng.lat);
+    const lng = parseFloat(e.detail.latLng.lng);
+    setLatLng({lat: lat, lng: lng});
+    setClickedMarkerId(null);
   }
 
   const handleButtonClick = () => {
@@ -43,7 +53,10 @@ export const IndexSpotLayout = () => {
   return (
     <Box sx={{display: "flex", flexDirection: "row", height: "100%"}} >
       <Box sx={{height: "100%", width :"100%"}} >
-        <MapView >
+        <MapView onClick={handleMapClick} >
+          {latLng &&
+            <MyMarker position={latLng} />
+          }
           <SpotIndex
             handleMarkerClick={handleMarkerClick}
             clickedMarkerId={clickedMarkerId}


### PR DESCRIPTION
## 概要
- スポット投稿画面のユーザビリティを向上させるため、以下を実施しました。
  - スポット一覧画面で地図上をクリックした際に、クリックした場所にピンを表示するようにしました。
  - ピンを表示した状態で「新規投稿」ボタンを押下すると、同じ位置にピンを表示したまま
  新規投稿画面に遷移するようにしました。

## 実施したこと
- [x] スポット一覧画面で、地図上をクリックした際にピンを刺せるように修正
  (既存のスポットをクリックした際は非表示にする)
[動画](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/2e665cce-c76d-463d-a492-8d2affdd63b5)

- [x] スポット一覧画面でピンを刺した状態で新規投稿ボタンを押した際に、ピンの`latLng`を
  `state`として新規投稿画面に渡すように修正
- [x] スポット新規投稿画面で表示させるピンを通常のマーカーから`AdvancedMarker`(`MyMarker`コンポーネント)に修正
[動画](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/003f9dae-f5af-4e68-87a6-d7171d4f5604)
(渋谷スクランブル交差点に刺したピンが、スポット新規投稿画面に引き継がれている)

