### PR TITLE
ユーザー情報編集機能

### DIFF
--- a/src/components/Elements/Buttons/UserConfigButton.jsx
+++ b/src/components/Elements/Buttons/UserConfigButton.jsx
@@ -2,20 +2,26 @@ import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Fade from '@mui/material/Fade';
-import { Button, IconButton } from '@mui/material';
-import { EditButton } from './EditButton';
+import { Box, Button, IconButton, Typography } from '@mui/material';
 import { LogOutButton } from '../../../features/auth/components/LogOutButton';
 import { WithdrawalButton } from '../../../features/users/components/WithdrawalButton';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import EditIcon from '@mui/icons-material/Edit';
 
-export const UserConfigButton = ({ currentUser, selectedSpot, setEditing }) => {
+export const UserConfigButton = ({ setEditing }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
+
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleEditButtonClicked = () => {
+    setAnchorEl(null);
+    setEditing(true);
   };
 
   return (
@@ -40,10 +46,17 @@ export const UserConfigButton = ({ currentUser, selectedSpot, setEditing }) => {
         onClose={handleClose}
         TransitionComponent={Fade}
       >
-        <MenuItem onClick={handleClose} >
-          <Button disabled >
-            <EditButton />
-          </Button>
+        <MenuItem onClick={handleEditButtonClicked} >
+          <Box
+            sx={{p: 0, m: 0}}
+            display={"flex"}
+            flexDirection={"row"}
+          >
+            <EditIcon fontSize="small" sx={{mr: 1}} />
+            <Typography >
+              編集
+            </Typography>
+          </Box>
         </MenuItem>
         <MenuItem onClick={handleClose} >
           <LogOutButton />

--- a/src/features/users/api/updateUser.js
+++ b/src/features/users/api/updateUser.js
@@ -1,0 +1,35 @@
+import { axios } from "../../../lib/axios";
+import { isAxiosError } from 'axios';
+
+export const updateUser = async (currentUser, userName, userId) => {
+  const token = await currentUser?.getIdToken();
+
+  if (!token) {
+    throw new Error('No token found');
+  }
+  const config = {
+    headers: { authorization: `Bearer ${token}` },
+  };
+
+  const data = {
+    user: {
+      name: userName,
+      uid: currentUser.uid,
+      avatar: currentUser.photoUrl
+    }
+  }
+
+  try {
+    const res = await axios.put(`/api/v1/users/${userId}`, data, config);
+    return res.data;
+  } catch (err) {
+    let message = '編集に失敗しました';
+    if (isAxiosError(err) && err.response) {
+      message = err.response.data.message || message;
+      throw new Error(message);
+    } else {
+      message = String(err);
+      throw new Error(message);
+    }
+  }
+}

--- a/src/features/users/components/UserProfile.jsx
+++ b/src/features/users/components/UserProfile.jsx
@@ -1,29 +1,75 @@
-import { Avatar, Box, Typography } from "@mui/material";
+import { Avatar, Box, Button, TextField, Typography } from "@mui/material";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import { UserConfigButton } from "../../../components/Elements/Buttons/UserConfigButton";
+import { useState } from "react";
+import { updateUser } from "../api/updateUser";
 
 export const UserProfile = ({ userInfo }) => {
-  const { loading, userId } = useFirebaseAuth();
+  const { loading, userId, currentUser } = useFirebaseAuth();
+  const [ editing, setEditing ] = useState(false);
+  const [ editedName, setEditedName ] = useState();
+  const [ updatedUser, setUpdatedUser ] = useState(null);
 
-  if (loading) {
+  const handleSubmitName = async (e) => {
+    e.preventDefault();
+    const updatedUser = await updateUser(currentUser, editedName, userId);
+    setUpdatedUser(updatedUser);
+    setEditing(false);
+  }
+
+  const handleEditName = (e) => {
+    setEditedName(e.target.value);
+  };
+
+  if (loading || !userId) {
     return <></>;
   }
 
   return (
     userInfo && (
-      <>
       <Box sx={{display: "flex", justifyContent: "center", alignItems: "center", width: "100%"}}>
-        <Box sx={{display: "flex", justifyContent: "space-between", width: "30%", maxWidth: "50%", py: 2}}>
-        <Box sx={{display: "flex", flexDirection: "row", alignItems: "end"}} >
-          <Avatar src={userInfo.avatar} sx={{mr: 3, width: 100, height: 100}}></Avatar>
-          <Typography fontSize="30px" >{userInfo.name}</Typography>
+        <Box sx={{display: "flex", justifyContent: "space-between", minWidth: "30%", maxWidth: "60%", py: 2}}>
+          {!editing ?
+            <Box sx={{display: "flex", flexDirection: "row", alignItems: "end"}} >
+                <Avatar src={updatedUser && updatedUser !== null ? updatedUser.avatar : userInfo.avatar} sx={{mr: 3, width: 100, height: 100}}></Avatar>
+                <Typography fontSize="30px" >{updatedUser && updatedUser !== null ? updatedUser.name : userInfo.name}</Typography>
+            </Box>
+          :
+          <Box sx={{display: "flex", flexDirection: "row", alignItems: "end"}} >
+            <Avatar src={userInfo.avatar} sx={{mr: 3, width: 100, height: 100}}></Avatar>
+              <form onSubmit={handleSubmitName}>
+                <Box display="flex" flexDirection="row">
+                  <Box bgcolor={"white"}>
+                    <TextField
+                      variant="outlined"
+                      color="info"
+                      defaultValue={`${updatedUser && updatedUser !== null ? updatedUser.name : userInfo.name}`}
+                      sx={{width: "300px"}}
+                      onChange={handleEditName}
+                    >
+                    </TextField>
+                  </Box>
+                  <Box display="flex" flexDirection="column" sx={{ml: 1, height: "100%"}} >
+                    <Button
+                      type="submit"
+                      color="success"
+                      variant="contained"
+                    >
+                      保存
+                    </Button>
+                    <Button onClick={() => setEditing(false)} variant="text" >
+                      <Typography fontSize={"12px"} >キャンセル</Typography>
+                    </Button>
+                  </Box>
+                </Box>
+              </form>
+            </Box>
+          }
         </Box>
-        {userId === userInfo.id &&
-          <UserConfigButton />
+        {!editing && userId === userInfo.id &&
+          <UserConfigButton setEditing={setEditing} />
         }
       </Box>
-      </Box>
-      </>
     )
   )
 }


### PR DESCRIPTION
## 概要
- ユーザープロフィールページで、ユーザー名を編集できるようにしました。

## 実施したこと
- [x] feat:ユーザー名を編集する機能を追加
- [x] add:ユーザー名を変更するため、API側に`PUT`リクエストを送信する`updateUser`を追加
- [x] update:ユーザー名編集用のビューを追加

![動画(ユーザー名編集)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f57060b4-e6fa-4e7e-9202-a624ec21acca)
