### PR TITLE
ユーザー情報機能の修正

### DIFF
--- a/src/features/users/components/UserProfile.jsx
+++ b/src/features/users/components/UserProfile.jsx
@@ -21,7 +21,7 @@ export const UserProfile = ({ userInfo }) => {
     setEditedName(e.target.value);
   };
 
-  if (loading || !userId) {
+  if (!userInfo) {
     return <></>;
   }
 


### PR DESCRIPTION
## 概要
- ユーザーのプロフィールを表示した際、ログイン状態でない場合には
ユーザー名が表示されないという不具合が発生していたので、修正しました。

## 実施したこと
- [x] fix:ユーザーのプロフィール表示の際、ログイン状態でない場合にはローディングを表示する分岐になっていたため修正

- 修正前
![動画(ユーザー名が表示されない修正前)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/0f523df3-92c6-46d4-b43f-8bf511addb5b)

- 修正後
![動画(ユーザー名が表示されない修正後)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/1a3222ae-1a38-432b-8d58-81bb8130769d)
