### PR TITLE
コメント投稿機能

### DIFF
--- a/src/components/Elements/Modals/CommentModal.jsx
+++ b/src/components/Elements/Modals/CommentModal.jsx
@@ -22,7 +22,7 @@ export default function CommentModal({ open, setOpen, spotId }) {
         <DialogContent sx={{py: 0}} >
           <CommentIndex spotId={spotId} isCommentPosted={isCommentPosted} />
         </DialogContent>
-        <CreateComment spotId={spotId} setIsCommentPosted={setIsCommentPosted} />
+        <CreateComment spotId={spotId} setIsCommentPosted={setIsCommentPosted} setOpen={setOpen} />
       </Dialog>
   );
 }

--- a/src/components/Elements/Modals/CommentModal.jsx
+++ b/src/components/Elements/Modals/CommentModal.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Box, Dialog, DialogContent, Typography } from '@mui/material';
+import { CommentIndex } from '../../../features/comments/components/CommentIndex';
+import { CreateComment } from '../../../features/comments/components/CreateComment';
+
+export default function CommentModal({ open, setOpen, spotId }) {
+  const [ isCommentPosted, setIsCommentPosted ] = useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+    setIsCommentPosted(false);
+  }
+
+  return (
+      <Dialog
+        open={open}
+        onClose={handleClose}
+      >
+        <Box sx={{textAlign: "center", py: 2}} >
+          <Typography >コメント</Typography>
+        </Box>
+        <DialogContent sx={{py: 0}} >
+          <CommentIndex spotId={spotId} isCommentPosted={isCommentPosted} />
+        </DialogContent>
+        <CreateComment spotId={spotId} setIsCommentPosted={setIsCommentPosted} />
+      </Dialog>
+  );
+}

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -8,6 +8,7 @@ import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 import SpotModal from "../Elements/Modals/SpotModal";
 import { useLocation } from 'react-router-dom';
 import { MyMarker } from "../Elements/Markers/MyMarker";
+import { CreateComment } from "../../features/comments/components/CreateComment";
 
 export const CreateSpotLayout = () => {
   const { currentUser, loading } = useFirebaseAuth();
@@ -62,6 +63,7 @@ export const CreateSpotLayout = () => {
       </Box>
       <Box sx={{height: "100%", width :"25%"}}>
         <CreateSpot latLng={latLng} setLatLng={setLatLng} setOpen={setOpen} setCreatedSpot={setCreatedSpot} />
+        <CreateComment />
       </Box>
     </Box>
   )

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -63,7 +63,6 @@ export const CreateSpotLayout = () => {
       </Box>
       <Box sx={{height: "100%", width :"25%"}}>
         <CreateSpot latLng={latLng} setLatLng={setLatLng} setOpen={setOpen} setCreatedSpot={setCreatedSpot} />
-        <CreateComment />
       </Box>
     </Box>
   )

--- a/src/features/comments/api/createComment.js
+++ b/src/features/comments/api/createComment.js
@@ -1,7 +1,7 @@
 import { axios } from "../../../lib/axios";
 import { isAxiosError } from 'axios';
 
-export const createComment = async ( currentUser, inputComment ) => {
+export const createComment = async ( currentUser, spotId, inputComment ) => {
   const token = await currentUser?.getIdToken();
 
   if (!token) {
@@ -12,14 +12,14 @@ export const createComment = async ( currentUser, inputComment ) => {
   };
 
   const data = {
-    cpmment: {
-      body: inputComment,
+    comment: {
+      content: inputComment,
+      spot_id: spotId,
     }
   }
 
   try {
     const res = await axios.post("/api/v1/comments", data, config);
-
     if (res.status === 201) {
       // 成功時はレスポンスデータ全体を返す
       return { success: true, data: res.data };

--- a/src/features/comments/api/createComment.js
+++ b/src/features/comments/api/createComment.js
@@ -1,0 +1,37 @@
+import { axios } from "../../../lib/axios";
+import { isAxiosError } from 'axios';
+
+export const createComment = async ( currentUser, inputComment ) => {
+  const token = await currentUser?.getIdToken();
+
+  if (!token) {
+    throw new Error('No token found');
+  }
+  const config = {
+    headers: { authorization: `Bearer ${token}` },
+  };
+
+  const data = {
+    cpmment: {
+      body: inputComment,
+    }
+  }
+
+  try {
+    const res = await axios.post("/api/v1/comments", data, config);
+
+    if (res.status === 201) {
+      // 成功時はレスポンスデータ全体を返す
+      return { success: true, data: res.data };
+    } else {
+      // ステータスコードが201以外の場合は、エラーメッセージを返す
+      throw new Error("スポットの投稿に失敗しました");
+    }
+  } catch (err) {
+    if (isAxiosError(err) && err.response) {
+      return { success: false, message: err.response.data.message || "エラーが発生しました" };
+    } else {
+      return { success: false, message: String(err) };
+    }
+  }
+}

--- a/src/features/comments/api/getComments.js
+++ b/src/features/comments/api/getComments.js
@@ -1,0 +1,16 @@
+import { axios } from "../../../lib/axios";
+
+export const getComments = async () => {
+  try {
+    const res = await axios.get("/api/v1/comments", null);
+    return res.data;
+  } catch (err) {
+    let message;
+    if (axios.isAxiosError(err) && err.response) {
+      console.error(err.response.data.message);
+    } else {
+      message = String(err);
+      console.error(message);
+    }
+  }
+}

--- a/src/features/comments/components/CommentIndex.jsx
+++ b/src/features/comments/components/CommentIndex.jsx
@@ -1,16 +1,16 @@
-import { Avatar, Box, Typography } from "@mui/material"
+import { Avatar, Box, Button, Typography } from "@mui/material"
 import { getComments } from "../api/getComments";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
-export const CommentIndex = ({ spotId }) => {
+export const CommentIndex = ({ spotId, isCommentPosted }) => {
   const [ fetchedComments, setFetchedComments ] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const fetchedData = await getComments();
-        console.log("ながさ", fetchedData.length);
-        if (fetchedData === null) {
+        if (fetchedData !== null) {
           const commentsForSpot = fetchedData.filter(data => parseInt(data.spot_id) === parseInt(spotId));
           setFetchedComments(commentsForSpot);
         } else {
@@ -21,35 +21,35 @@ export const CommentIndex = ({ spotId }) => {
       }
     }
     fetchData();
-  }, [])
-
-  console.log("コメントの中身", fetchedComments)
+  }, [isCommentPosted])
 
   return (
-    <Box sx={{mt: 4, px: 2}} >
-      <Box sx={{textAlign: "center", pb: 1}} >
-        <Typography >コメント</Typography>
-      </Box>
-      {fetchedComments && fetchedComments.length > 0 ?
-        <>
-          {fetchedComments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).map((comment) => (
-            <Box key={comment.id} sx={{py: 1, px: 1}}>
-              <Box sx={{display: "flex", flexDirection: "row", alignItems: "flex-end", gap: 2}} >
-                <Avatar src={comment.user.avatar} />
-                <Typography fontWeight="bold" >{comment.user.name}</Typography>
-                <Typography fontSize="14px" >{new Date(comment.created_at).toLocaleDateString()}</Typography>
+    <Box sx={{px: 2}} >
+      {fetchedComments ?
+        fetchedComments.length > 0 ?
+          <>
+            {fetchedComments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).map((comment) => (
+              <Box key={comment.id} sx={{pb: 1, px: 1}}>
+                <Box sx={{display: "flex", flexDirection: "row", alignItems: "flex-end", gap: 2}} >
+                  <Button component={Link} to={`/users/${comment.user.id}`} sx={{alignItems: "flex-end",  gap: 2, pb: 0}} >
+                    <Avatar src={comment.user.avatar} />
+                    <Typography fontWeight="bold" >{comment.user.name}</Typography>
+                  </Button>
+                  <Typography fontSize="14px" >{new Date(comment.created_at).toLocaleDateString()}</Typography>
+                </Box>
+                <Box sx={{display: "flex", justifyContent: "left", py: 1, px: 3}} >
+                  <Typography >{comment.content}</Typography>
+                </Box>
               </Box>
-              <Box sx={{display: "flex", justifyContent: "left", py: 1, px: 3}} >
-                <Typography >{comment.content}</Typography>
-              </Box>
-            </Box>
-          ))
-          }
-        </>
+            ))
+            }
+          </>
+        :
+          <Box sx={{textAlign: "center", pt: 1}} >
+            <Typography >まだコメントはありません</Typography>
+          </Box>
       :
-        <Box sx={{textAlign: "center", pt: 1}} >
-          <Typography >まだコメントはありません</Typography>
-        </Box>
+        <></>
       }
     </Box>
   )

--- a/src/features/comments/components/CommentIndex.jsx
+++ b/src/features/comments/components/CommentIndex.jsx
@@ -1,0 +1,56 @@
+import { Avatar, Box, Typography } from "@mui/material"
+import { getComments } from "../api/getComments";
+import { useEffect, useState } from "react";
+
+export const CommentIndex = ({ spotId }) => {
+  const [ fetchedComments, setFetchedComments ] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const fetchedData = await getComments();
+        console.log("ながさ", fetchedData.length);
+        if (fetchedData === null) {
+          const commentsForSpot = fetchedData.filter(data => parseInt(data.spot_id) === parseInt(spotId));
+          setFetchedComments(commentsForSpot);
+        } else {
+          setFetchedComments(null);
+        }
+      } catch (error) {
+        console.error('コメントの取得に失敗しました', error);
+      }
+    }
+    fetchData();
+  }, [])
+
+  console.log("コメントの中身", fetchedComments)
+
+  return (
+    <Box sx={{mt: 4, px: 2}} >
+      <Box sx={{textAlign: "center", pb: 1}} >
+        <Typography >コメント</Typography>
+      </Box>
+      {fetchedComments && fetchedComments.length > 0 ?
+        <>
+          {fetchedComments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).map((comment) => (
+            <Box key={comment.id} sx={{py: 1, px: 1}}>
+              <Box sx={{display: "flex", flexDirection: "row", alignItems: "flex-end", gap: 2}} >
+                <Avatar src={comment.user.avatar} />
+                <Typography fontWeight="bold" >{comment.user.name}</Typography>
+                <Typography fontSize="14px" >{new Date(comment.created_at).toLocaleDateString()}</Typography>
+              </Box>
+              <Box sx={{display: "flex", justifyContent: "left", py: 1, px: 3}} >
+                <Typography >{comment.content}</Typography>
+              </Box>
+            </Box>
+          ))
+          }
+        </>
+      :
+        <Box sx={{textAlign: "center", pt: 1}} >
+          <Typography >まだコメントはありません</Typography>
+        </Box>
+      }
+    </Box>
+  )
+}

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -16,7 +16,7 @@ const style = {
   padding: "10px 0px 20px 0px"
 }
 
-export const CreateComment = ({ spotId, setIsCommentPosted }) => {
+export const CreateComment = ({ spotId, setIsCommentPosted, setOpen }) => {
   const { currentUser } = useFirebaseAuth();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ inputComment, setInputComment ] = useState(null);
@@ -38,11 +38,15 @@ export const CreateComment = ({ spotId, setIsCommentPosted }) => {
       setIsSuccessMessage(true);
       setInputComment("");
       setIsCommentPosted(true);
+    } else {
+      console.log(result)
+      setMessage(result.message);
     }
   }
 
   const handleCancelClick = () => {
     setInputComment("");
+    setOpen(false);
   }
 
   return (

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -1,6 +1,9 @@
 import { Box, Button, TextField, Typography } from "@mui/material"
 import SendIcon from '@mui/icons-material/Send';
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { createComment } from "../api/createComment";
+import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 
 const style = {
   display: 'flex',
@@ -13,12 +16,28 @@ const style = {
   paddingTop: "30px"
 }
 
-export const CreateComment = () => {
+export const CreateComment = ({ spotId }) => {
+  const { currentUser } = useFirebaseAuth();
+  const { setMessage, setIsSuccessMessage } = useFlashMessage();
   const [ inputComment, setInputComment ] = useState();
+  const [ isDisabled, setIsDisabled ] = useState(true);
 
-  const handleCommentCteate = (e) => {
+  useEffect(() => {
+    if(inputComment !== null && inputComment !== "" ) {
+      setIsDisabled(false);
+    } else {
+      setIsDisabled(true);
+    }
+  }, [inputComment])
+
+  const handleCommentCteate = async (e) => {
     e.preventDefault();
-
+    const result = await createComment(currentUser, spotId, inputComment);
+    if (result.success) {
+      setMessage("コメントしました");
+      setIsSuccessMessage(true);
+      setInputComment("");
+    }
   }
 
   const handleCancelClick = () => {
@@ -49,6 +68,7 @@ export const CreateComment = () => {
           variant='contained'
           display={"flex"}
           sx={{width: "150px"}}
+          disabled={isDisabled}
         >
           投稿
         </Button>

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -1,0 +1,58 @@
+import { Box, Button, TextField, Typography } from "@mui/material"
+import SendIcon from '@mui/icons-material/Send';
+import { useState } from "react";
+
+const style = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: "100%",
+  width: '90%',
+  textAlign: 'center',
+  alignItems: "center",
+  margin: "0 auto",
+  paddingTop: "30px"
+}
+
+export const CreateComment = () => {
+  const [ inputComment, setInputComment ] = useState();
+
+  const handleCommentCteate = (e) => {
+    e.preventDefault();
+
+  }
+
+  const handleCancelClick = () => {
+    setInputComment("");
+  }
+
+  return (
+    <Box style={style} >
+      <form onSubmit={handleCommentCteate} >
+        <Typography variant='h5' fontSize={"24px"}>
+        </Typography>
+        <TextField
+          id="comment"
+          label="コメント"
+          fullWidth
+          variant="outlined"
+          color="info"
+          margin="normal"
+          placeholder="コメントを入力"
+          name="comment"
+          value={inputComment}
+          onChange={(e) => setInputComment(e.target.value)}
+        />
+        <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
+        <Button
+          type='submit'
+          color='info'
+          variant='contained'
+          display={"flex"}
+          sx={{width: "150px"}}
+        >
+          投稿
+        </Button>
+      </form>
+    </Box>
+  )
+}

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -13,13 +13,13 @@ const style = {
   textAlign: 'center',
   alignItems: "center",
   margin: "0 auto",
-  paddingTop: "30px"
+  padding: "10px 0px 20px 0px"
 }
 
-export const CreateComment = ({ spotId }) => {
+export const CreateComment = ({ spotId, setIsCommentPosted }) => {
   const { currentUser } = useFirebaseAuth();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
-  const [ inputComment, setInputComment ] = useState();
+  const [ inputComment, setInputComment ] = useState(null);
   const [ isDisabled, setIsDisabled ] = useState(true);
 
   useEffect(() => {
@@ -37,6 +37,7 @@ export const CreateComment = ({ spotId }) => {
       setMessage("コメントしました");
       setIsSuccessMessage(true);
       setInputComment("");
+      setIsCommentPosted(true);
     }
   }
 

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -49,6 +49,11 @@ export const CreateComment = ({ spotId, setIsCommentPosted, setOpen }) => {
     setOpen(false);
   }
 
+  const handleCommentInput = (e) => {
+    setInputComment(e.target.value);
+    setIsCommentPosted(false);
+  }
+
   return (
     <Box style={style} >
       <form onSubmit={handleCommentCteate} >
@@ -64,7 +69,7 @@ export const CreateComment = ({ spotId, setIsCommentPosted, setOpen }) => {
           placeholder="コメントを入力"
           name="comment"
           value={inputComment}
-          onChange={(e) => setInputComment(e.target.value)}
+          onChange={handleCommentInput}
         />
         <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
         <Button

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -9,6 +9,7 @@ import { ConfigButton } from "../../../components/Elements/Buttons/ConfigButton"
 import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
 import { ShareButton } from "../../../components/Elements/Buttons/ShareButton";
 import { CreateComment } from "../../comments/components/CreateComment";
+import { CommentIndex } from "../../comments/components/CommentIndex";
 
 export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoClick, handleClose }) => {
   const { spots } = useSpotsContext();
@@ -112,6 +113,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
           <Box sx={{px: 2, mt: 2}}>
             <Typography >{selectedSpot.description}</Typography>
           </Box>
+          <CommentIndex spotId={spotId} />
           <CreateComment spotId={spotId} />
         </Box>
       :

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -6,15 +6,15 @@ import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import { LikeButton } from "../../../components/Elements/Buttons/LikeButton";
 import { EditSpot } from "./EditSpot";
 import { ConfigButton } from "../../../components/Elements/Buttons/ConfigButton";
-import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
 import { ShareButton } from "../../../components/Elements/Buttons/ShareButton";
-import { CreateComment } from "../../comments/components/CreateComment";
-import { CommentIndex } from "../../comments/components/CommentIndex";
+import CommentModal from "../../../components/Elements/Modals/CommentModal";
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 
 export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoClick, handleClose }) => {
   const { spots } = useSpotsContext();
   const { currentUser, userId } = useFirebaseAuth();
   const [ editing, setEditing ] = useState(false);
+  const [ commentModalOpen, setCommentModalOpen ] = useState(false);
 
   useEffect(() => {
     if (spots) {
@@ -98,9 +98,9 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
           </Box>
           <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%"}}>
             <Box sx={{display: "flex", justifyContent: "left", alignItems: "center", width: "100%"}}>
-              <Tooltip title="コメントする(機能作成中)">
+              <Tooltip title="コメント">
                 <span>
-                  <IconButton sx={{mx: 2}} disabled ><ChatBubbleIcon /></IconButton>
+                  <IconButton sx={{mx: 2}} onClick={() => setCommentModalOpen(true)} ><ChatBubbleOutlineIcon /></IconButton>
                 </span>
               </Tooltip>
               <LikeButton
@@ -113,8 +113,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
           <Box sx={{px: 2, mt: 2}}>
             <Typography >{selectedSpot.description}</Typography>
           </Box>
-          <CommentIndex spotId={spotId} />
-          <CreateComment spotId={spotId} />
+          <CommentModal open={commentModalOpen} setOpen={setCommentModalOpen} spotId={spotId} />
         </Box>
       :
         <EditSpot spot={selectedSpot} setEditing={setEditing} title={"スポット編集"} />

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -8,6 +8,7 @@ import { EditSpot } from "./EditSpot";
 import { ConfigButton } from "../../../components/Elements/Buttons/ConfigButton";
 import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
 import { ShareButton } from "../../../components/Elements/Buttons/ShareButton";
+import { CreateComment } from "../../comments/components/CreateComment";
 
 export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoClick, handleClose }) => {
   const { spots } = useSpotsContext();
@@ -111,6 +112,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
           <Box sx={{px: 2, mt: 2}}>
             <Typography >{selectedSpot.description}</Typography>
           </Box>
+          <CreateComment spotId={spotId} />
         </Box>
       :
         <EditSpot spot={selectedSpot} setEditing={setEditing} title={"スポット編集"} />


### PR DESCRIPTION
## 概要
- 投稿されたスポットに対して、コメントを投稿できる機能を実装しました。
- コメント投稿、表示ともに、モーダルで実施するようにしました。
  - スポット詳細のコメントボタンを押下した際に、モーダルを開くようにしました。

## 実施したこと
- [x] コメント投稿フォームを作成
- [x] フォームの送信ボタンを押下した際、Rails API側にデータを送信する処理を作成
- [x] 保存されたコメントを表示するビューを作成
- [x] 保存されたコメントをAPI側から取得するファイルを作成
- [x] コメント投稿成功時のフラッシュメッセージを作成
- [x] コメント投稿失敗時のフラッシュメッセージを作成

コメントを表示するモーダル
![動画(コメントモーダル)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/e703d50a-c02a-4251-b554-5f7970ae8f7d)

コメント投稿成功時
![動画(コメント投稿成功)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/b7e30aa4-021c-428b-ba0d-e34eda9aec65)

コメント投稿失敗時
![動画(コメント投稿失敗)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/d1d79c4d-14bc-4ec9-972d-17f7974f87eb)
