### PR TITLE
コメント削除機能

### DIFF
--- a/src/features/comments/api/deleteComment.js
+++ b/src/features/comments/api/deleteComment.js
@@ -1,0 +1,28 @@
+import { axios } from "../../../lib/axios";
+import { isAxiosError } from 'axios';
+
+export const deleteComment = async ( currentUser, commentId, setIsSuccessMessage ) => {
+  const token = await currentUser?.getIdToken()
+
+  if (!token) {
+    throw new Error('No token found');
+  }
+  const config = {
+    headers: { authorization: `Bearer ${token}` },
+  };
+
+  try {
+    const res = await axios.delete(`/api/v1/comments/${commentId}`, config);
+    setIsSuccessMessage(true);
+    return res.data.message;
+  } catch (err) {
+    let message = '削除に失敗しました';
+    if (isAxiosError(err) && err.response) {
+      message = err.response.data.message || message;
+      throw new Error(message);
+    } else {
+      message = String(err);
+      throw new Error(message);
+    }
+  }
+}

--- a/src/features/comments/components/CommentIndex.jsx
+++ b/src/features/comments/components/CommentIndex.jsx
@@ -2,9 +2,13 @@ import { Avatar, Box, Button, Typography } from "@mui/material"
 import { getComments } from "../api/getComments";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { DeleteComment } from "./DeleteComment";
+import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 
 export const CommentIndex = ({ spotId, isCommentPosted }) => {
   const [ fetchedComments, setFetchedComments ] = useState(null);
+  const { currentUser, userId } = useFirebaseAuth();
+  const [ commentDeleted, setCommentDeleted ] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -13,6 +17,7 @@ export const CommentIndex = ({ spotId, isCommentPosted }) => {
         if (fetchedData !== null) {
           const commentsForSpot = fetchedData.filter(data => parseInt(data.spot_id) === parseInt(spotId));
           setFetchedComments(commentsForSpot);
+          setCommentDeleted(false);
         } else {
           setFetchedComments(null);
         }
@@ -21,7 +26,7 @@ export const CommentIndex = ({ spotId, isCommentPosted }) => {
       }
     }
     fetchData();
-  }, [isCommentPosted])
+  }, [isCommentPosted, commentDeleted])
 
   return (
     <Box sx={{px: 2}} >
@@ -30,12 +35,17 @@ export const CommentIndex = ({ spotId, isCommentPosted }) => {
           <>
             {fetchedComments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).map((comment) => (
               <Box key={comment.id} sx={{pb: 1, px: 1}}>
-                <Box sx={{display: "flex", flexDirection: "row", alignItems: "flex-end", gap: 2}} >
-                  <Button component={Link} to={`/users/${comment.user.id}`} sx={{alignItems: "flex-end",  gap: 2, pb: 0}} >
-                    <Avatar src={comment.user.avatar} />
-                    <Typography fontWeight="bold" >{comment.user.name}</Typography>
-                  </Button>
-                  <Typography fontSize="14px" >{new Date(comment.created_at).toLocaleDateString()}</Typography>
+                <Box display="flex" justifyContent="space-between" >
+                  <Box sx={{display: "flex", flexDirection: "row", alignItems: "flex-end", gap: 2}} >
+                    <Button component={Link} to={`/users/${comment.user.id}`} sx={{alignItems: "flex-end",  gap: 2, pb: 0}} >
+                      <Avatar src={comment.user.avatar} />
+                      <Typography fontWeight="bold" >{comment.user.name}</Typography>
+                    </Button>
+                    <Typography fontSize="14px" >{new Date(comment.created_at).toLocaleDateString()}</Typography>
+                  </Box>
+                  {userId && comment.user_id === userId &&
+                    <DeleteComment commentId={comment.id} currentUser={currentUser} setCommentDeleted={setCommentDeleted} />
+                  }
                 </Box>
                 <Box sx={{display: "flex", justifyContent: "left", py: 1, px: 3}} >
                   <Typography >{comment.content}</Typography>

--- a/src/features/comments/components/DeleteComment.jsx
+++ b/src/features/comments/components/DeleteComment.jsx
@@ -1,0 +1,22 @@
+import { Button, IconButton } from "@mui/material"
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
+import { deleteComment } from "../api/deleteComment";
+
+export const DeleteComment = ({ commentId, currentUser, setCommentDeleted }) => {
+  const { setMessage, setIsSuccessMessage } = useFlashMessage();
+
+  const handleDeleteClick = async () => {
+    try {
+      await deleteComment(currentUser, commentId, setIsSuccessMessage);
+      setMessage("削除しました");
+      setCommentDeleted(true);
+    } catch (error) {
+      setMessage(error.message);
+    }
+  }
+
+  return (
+    <IconButton variant="contained" color="error" onClick={handleDeleteClick} ><DeleteForeverIcon /></IconButton>
+  )
+}


### PR DESCRIPTION
## 概要
- コメント削除機能を実装しました。
  - コメントの右上に表示される削除ボタン(ゴミ箱アイコン)を削除するとコメントが削除されます。
  - ログイン中のユーザーが投稿したコメントのみ、削除ボタンを表示するようにしました。
## 実施したこと
- [x] コメント削除ボタンを作成
- [x] ログイン中のユーザーが投稿したコメントのみに削除ボタンを表示する
- [x] コメント削除ボタンを押下した際、Rails API側にデータを送信する処理を作成
  - [x]  destroyアクションを作成
- [x]  投稿されたコメントを画面から削除する機能を作成

### 動画
![動画(コメント削除)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/1bcaa3a6-8a7e-4512-9910-e1d4e88a2494)
