### PR TITLE
レスポンシブ対応

### DIFF
--- a/src/components/Elements/Modals/MessageModal.jsx
+++ b/src/components/Elements/Modals/MessageModal.jsx
@@ -11,7 +11,10 @@ const style = {
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: 400,
+  width: {
+    xs: "80%",
+    sm: 400
+  },
   bgcolor: 'background.paper',
   boxShadow: 24,
   p: 4,

--- a/src/components/Elements/Modals/SpotDetailModal.jsx
+++ b/src/components/Elements/Modals/SpotDetailModal.jsx
@@ -25,7 +25,14 @@ export default function SpotDetailModal({ spotId, open, setOpen }) {
         onClose={handleClose}
         open={open}
       >
-        <DialogContent sx={{height: "100vh", p: 0, m: 0}}>
+        <DialogContent
+          sx={{
+            height: "100%",
+            p: { xs: 1, sm: 0 },
+            pb: { xs: 2, sm: 3 },
+            m: 0
+          }}
+        >
           <SpotDetail spotId={spotId} selectedSpot={selectedSpot} setSelectedSpot={setSelectedSpot} handleVideoClick={handleVideoClick} handleClose={handleClose} />
         </DialogContent>
       </Dialog>

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -14,11 +14,16 @@ const style = {
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: 400,
+  width: {
+    xs: "100%",
+    sm: "400px"
+  },
+  maxHeight: {
+    xs: "80%",
+  },
   bgcolor: 'background.paper',
-  // border: '2px solid #000',
   boxShadow: 24,
-  p: 4,
+  p: {xs: 1, sm: 4},
   textAlign: "center"
 };
 
@@ -50,15 +55,41 @@ export default function SpotModal({open, setOpen, spot, setLatLng}) {
         {spot &&
           <Box sx={style}>
             {buttonType === "close" && <IconButton onClick={handleClose}><CloseIcon variant={"contained"} color={"info"} /></IconButton>}
-            <Typography id="modal-modal-title" variant="h6" component="h2">
+            <Typography
+              id="modal-modal-title"
+              fontSize={{xs: "16px", sm: "20px"}}
+              fontWeight="bold"
+              pb={1}
+              component="h2"
+            >
               {spot.title}
             </Typography>
-            <img src={spot.url} />
-            <Typography sx={{pt: 2}}>{spot.body}</Typography>
-            <Box sx={{pt: 2, display: "flex", flexDirection: "column", alignItems: "center"}} textAlign={"center"}>
+            <Box display="flex" justifyContent="center" margin="auto" width={{xs: "70%", sm: "100%"}} >
+              <img src={spot.url} style={{maxWidth: "80%", height: "auto"}} />
+            </Box>
+            <Typography sx={{pt: { xs: 1, sm: 2 }}}>{spot.body}</Typography>
+
+            {/* スマートフォンサイズのボタン */}
+            <Box
+              sx={{
+                // pt: 1,
+                display: { xs: "flex", sm: "none" },
+                flexDirection: "column",
+                alignItems: "center"
+              }}
+              textAlign={"center"}
+            >
+              <Box
+                sx={{
+                  display: { xs: "flex", sm: "none" },
+                  flexDirection: "row",
+                  alignItems: "center"
+                }}
+              >
               <Button
                 onClick={handleNextPost}
-                text={"ログイン"} sx={{width: "40%", my: 1}}
+                text={"ログイン"}
+                sx={{width: { xs: "80%", sm: "50%" }, my: 1, mr: 1}}
                 variant={"outlined"}
                 color={"info"}
               >
@@ -67,7 +98,39 @@ export default function SpotModal({open, setOpen, spot, setLatLng}) {
               <Button
                 onClick={handleSpotDetail}
                 text={"ログイン"}
-                sx={{width: "40%", my: 1}}
+                sx={{width: { xs: "80%", sm: "50%" }, my: 1}}
+                variant={"contained"}
+                color={"info"}
+              >
+                投稿を確認する
+              </Button>
+              </Box>
+            </Box>
+
+
+            {/* タブレット以上のサイズのボタン */}
+            <Box
+              sx={{
+                pt: 2,
+                display: { xs: "none", sm: "flex" },
+                flexDirection: "column",
+                alignItems: "center"
+              }}
+              textAlign={"center"}
+            >
+              <Button
+                onClick={handleNextPost}
+                text={"ログイン"}
+                sx={{width: { xs: "80%", sm: "50%" }, my: 1}}
+                variant={"outlined"}
+                color={"info"}
+              >
+                続けて投稿する
+              </Button>
+              <Button
+                onClick={handleSpotDetail}
+                text={"ログイン"}
+                sx={{width: { xs: "80%", sm: "50%" }, my: 1}}
                 variant={"contained"}
                 color={"info"}
               >
@@ -75,6 +138,8 @@ export default function SpotModal({open, setOpen, spot, setLatLng}) {
               </Button>
               <ShareButton url={`https://twitter.com/share?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} (※PC💻環境より閲覧してください)&text=${spot.body}を投稿したよ！🎉【BackHacker.】で見に行かない？🌎%0a%0a`} />
             </Box>
+
+
           </Box>
         }
       </Modal>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -5,11 +5,20 @@ import { Link } from 'react-router-dom';
 export const Footer = () => {
   return (
     <Box
-      sx={{bgcolor: "primary.main", height: "2.5rem", px: { xs: 1, sm: 10, md: 15 }, pb: { xs: 1, sm: 0, md: 0 } }}
+      sx={{
+        bgcolor: "primary.main",
+        height: "2.5rem",
+        px: { xs: 1, sm: 10, md: 15 },
+        py: { xs: 1, sm: 0 }
+      }}
       display="flex"
       justifyContent="space-between"
       alignItems="center"
-      flexDirection={{ xs: "column", sm: "row", md: "row" }}
+      flexDirection={{
+        xs: "column",
+        sm: "row",
+        md: "row"
+      }}
     >
       <Box display="flex" sx={{gap: 5}} >
         <Link

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -5,10 +5,11 @@ import { Link } from 'react-router-dom';
 export const Footer = () => {
   return (
     <Box
-      sx={{bgcolor: "primary.main", height: "2.5rem", px: 15}}
+      sx={{bgcolor: "primary.main", height: "2.5rem", px: { xs: 1, sm: 10, md: 15 }, pb: { xs: 1, sm: 0, md: 0 } }}
       display="flex"
       justifyContent="space-between"
       alignItems="center"
+      flexDirection={{ xs: "column", sm: "row", md: "row" }}
     >
       <Box display="flex" sx={{gap: 5}} >
         <Link

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -152,7 +152,7 @@ export default function Header() {
 
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static" sx={{pl: 5}}>
+      <AppBar position="static" sx={{ pl: {xs: 0, sm: 1, md: 5} }}>
         <Toolbar>
           <Link
               to={`${currentUser ? "/map" : "/"}`}
@@ -162,7 +162,7 @@ export default function Header() {
               variant="h6"
               noWrap
               component="div"
-              sx={{ display: { xs: 'none', sm: 'block' } }}
+              sx={{ display: { xs: 'block', sm: 'block' } }}
             >
               BackHacker.
             </Typography>

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -8,7 +8,6 @@ import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 import SpotModal from "../Elements/Modals/SpotModal";
 import { useLocation } from 'react-router-dom';
 import { MyMarker } from "../Elements/Markers/MyMarker";
-import { CreateComment } from "../../features/comments/components/CreateComment";
 
 export const CreateSpotLayout = () => {
   const { currentUser, loading } = useFirebaseAuth();

--- a/src/components/Layout/CreateSpotLayout.jsx
+++ b/src/components/Layout/CreateSpotLayout.jsx
@@ -45,7 +45,7 @@ export const CreateSpotLayout = () => {
   }
 
   return (
-    <Box sx={{display: "flex", flexDirection: "row", height: "100%"}} >
+    <Box sx={{display: "flex", flexDirection: { xs: "column", sm: "row" }, height: "100%"}} >
       {createdSpot && createdSpot !== null &&
         <SpotModal
           open={open}
@@ -54,14 +54,26 @@ export const CreateSpotLayout = () => {
           setLatLng={setLatLng}
         />
       }
-      <Box sx={{height: "100%", width :"75%"}} >
+      <Box
+        display={{xs: "block", sm: "block"}}
+        sx={{
+          height: { xs: "70%", sm: "100%" },
+          width : { xs: "100%", sm: "75%" }
+        }}
+      >
         <MapView onClick={handleMapClick} >
           {latLng &&
             <MyMarker position={latLng} />
           }
         </MapView>
       </Box>
-      <Box sx={{height: "100%", width :"25%"}}>
+      <Box
+        display={{xs: "block", sm: "block"}}
+        sx={{
+          height: { xs: "30%", sm: "100%" },
+          width : { xs: "100%", sm: "25%" }
+        }}
+      >
         <CreateSpot latLng={latLng} setLatLng={setLatLng} setOpen={setOpen} setCreatedSpot={setCreatedSpot} />
       </Box>
     </Box>

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -183,13 +183,14 @@ export const HeroLayout = () => {
 
       <Box
         sx={{
-          minHeight: { sm: "calc(100vh - 4rem)", md: "calc(100vh - 2.5rem)" },
+          minHeight: "calc(100vh - 2.5rem)",
           display: "flex",
           flexDirection: "column",
           text: "center",
           alignItems: "center",
+          justifyContent: { xs: "center", sm: "none" },
           px: { xs: 1 },
-          pb: { xs: 2, sm: 1 }
+          pb: { xs: 3, sm: 1 },
         }}
         bgcolor={"primary.dark"}
         ref={scrollToBottomRef}
@@ -197,14 +198,14 @@ export const HeroLayout = () => {
         <Typography
           fontSize={{ xs: "20px", sm: "32px" }}
           color={"white"}
-          sx={{pt: { xs: 2, sm: 8, md: 5 }}}
+          sx={{pt: { xs: 2, sm: 8, md: 8 }}}
         >
           BackHacker.でできること
         </Typography>
         <Box
           sx={{
             display: "flex",
-            height: { xs: "100%", md: "50vh" },
+            height: { xs: "100%", md: "100%" },
             flexDirection: { xs: "row", sm: "column" },
             alignItems: "center",
             justifyContent: "center", // 追加
@@ -216,7 +217,7 @@ export const HeroLayout = () => {
             spacing={{ xs: 1, sm: 3, md: 3 }}
             sx={{
               flexDirection: { xs: "column", sm: "row" },
-              width: { xs: "100%", sm: '80%' },
+              width: { xs: "100%", sm: '80%', lg: "90%" },
               mb: { xs: 0, sm: 1 },
               justifyContent: "center", // 追加
               alignItems: "flex-start" // 追加
@@ -234,7 +235,7 @@ export const HeroLayout = () => {
             >
               <OndemandVideoIcon fontSize="large" color="secondary"/>
               <Typography
-                display={{ xs: "block", md: "none" }}
+                display={{ xs: "block", md: "none", lg: "block" }}
                 fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
                 color={"white"}
                 sx={{mb: 2}}
@@ -242,10 +243,10 @@ export const HeroLayout = () => {
                 世界中の街の動画を楽しむ
               </Typography>
               <Typography
-                display={{ xs: "none", md: "block" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                display={{ xs: "none", md: "block", lg: "none" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "30px" }}
                 color={"white"}
-                sx={{mb: 2, minHeight: "180px"}}
+                sx={{mb: 2, minHeight: "140px"}}
               >
                 世界中の街の動画を楽しむ
               </Typography>
@@ -268,7 +269,7 @@ export const HeroLayout = () => {
             >
               <GroupsIcon fontSize="large" color="secondary"/>
               <Typography
-                display={{ xs: "block", md: "none" }}
+                display={{ xs: "block", md: "none", lg: "block" }}
                 fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
                 color={"white"}
                 sx={{mb: 2}}
@@ -276,10 +277,10 @@ export const HeroLayout = () => {
                 みんなの投稿したスポットを見にいく
               </Typography>
               <Typography
-                display={{ xs: "none", md: "block" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                display={{ xs: "none", md: "block", lg: "none" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "30px" }}
                 color={"white"}
-                sx={{mb: 2, minHeight: "180px"}}
+                sx={{mb: 2, minHeight: "140px"}}
               >
                 みんなの投稿したスポットを見にいく
               </Typography>
@@ -302,7 +303,7 @@ export const HeroLayout = () => {
             >
               <ThumbUpIcon fontSize="large" color="secondary"/>
               <Typography
-                display={{ xs: "block", md: "none" }}
+                display={{ xs: "block", md: "none", lg: "block" }}
                 fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
                 color={"white"}
                 sx={{mb: 2}}
@@ -310,10 +311,10 @@ export const HeroLayout = () => {
                 コメント、いいね、シェアでつながる
               </Typography>
               <Typography
-                display={{ xs: "none", md: "block" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                display={{ xs: "none", md: "block", lg: "none" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "30px" }}
                 color={"white"}
-                sx={{mb: 2, minHeight: "180px"}}
+                sx={{mb: 2, minHeight: "140px"}}
               >
                 コメント、いいね、シェアでつながる
               </Typography>

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -9,7 +9,7 @@ import { useRef } from "react";
 
 const styleForHero = {
   backgroundImage: "url('/heroImage.jpg')",
-  height: '100vh',
+  // height: '100vh',
   backgroundSize: 'cover',
   backgroundRepeat: 'no-repeat',
   backgroundPosition: 'center',
@@ -115,14 +115,15 @@ export const HeroLayout = () => {
       <Box
         ref={scrollToMidRef}
         sx={{
+          ...styleForHero,
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           position: "relative",
+          minHeight: "100vh"
         }}
         bgcolor={"primary.dark"}
-        style={styleForHero}
       >
         <Box
           sx={{width: {xs: "90%", sm: "80%"} }}

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -13,7 +13,7 @@ const styleForHero = {
   backgroundSize: 'cover',
   backgroundRepeat: 'no-repeat',
   backgroundPosition: 'center',
-  backgroundColor: "rgba(255,255,255,0.2)",
+  backgroundColor: "rgba(255,255,255,0.3)",
   backgroundBlendMode: "lighten"
 };
 
@@ -128,6 +128,13 @@ export const HeroLayout = () => {
           sx={{width: {xs: "90%", sm: "80%"} }}
         >
           <Typography
+            fontSize={{ xs: "16px", sm: "32px", md: "38px" }}
+            color={{ xs: "black", sm: "gray" }}
+            sx={{mb: 1}}
+          >
+            CONCEPT
+          </Typography>
+          <Typography
             fontSize={{ xs: "24px", sm: "50px", md: "60px" }}
             color={"black"}
             fontWeight={"bold"}
@@ -235,8 +242,8 @@ export const HeroLayout = () => {
             >
               <OndemandVideoIcon fontSize="large" color="secondary"/>
               <Typography
-                display={{ xs: "block", md: "none", lg: "block" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                display={{ xs: "block", md: "none" }}
+                fontSize={{ xs: "16px", sm: "24px" }}
                 color={"white"}
                 sx={{mb: 2}}
               >
@@ -244,9 +251,17 @@ export const HeroLayout = () => {
               </Typography>
               <Typography
                 display={{ xs: "none", md: "block", lg: "none" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "30px" }}
+                fontSize={{ md: "30px" }}
                 color={"white"}
                 sx={{mb: 2, minHeight: "140px"}}
+              >
+                世界中の街の動画を楽しむ
+              </Typography>
+              <Typography
+                display={{ xs: "none", lg: "block" }}
+                fontSize={{ lg: "36px" }}
+                color={"white"}
+                sx={{mb: 2, minHeight: "110px"}}
               >
                 世界中の街の動画を楽しむ
               </Typography>
@@ -269,8 +284,8 @@ export const HeroLayout = () => {
             >
               <GroupsIcon fontSize="large" color="secondary"/>
               <Typography
-                display={{ xs: "block", md: "none", lg: "block" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                display={{ xs: "block", md: "none" }}
+                fontSize={{ xs: "16px", sm: "24px" }}
                 color={"white"}
                 sx={{mb: 2}}
               >
@@ -278,9 +293,17 @@ export const HeroLayout = () => {
               </Typography>
               <Typography
                 display={{ xs: "none", md: "block", lg: "none" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "30px" }}
+                fontSize={{ md: "30px" }}
                 color={"white"}
                 sx={{mb: 2, minHeight: "140px"}}
+              >
+                みんなの投稿したスポットを見にいく
+              </Typography>
+              <Typography
+                display={{ xs: "none", lg: "block" }}
+                fontSize={{ lg: "36px" }}
+                color={"white"}
+                sx={{mb: 2, minHeight: "110px"}}
               >
                 みんなの投稿したスポットを見にいく
               </Typography>
@@ -303,8 +326,8 @@ export const HeroLayout = () => {
             >
               <ThumbUpIcon fontSize="large" color="secondary"/>
               <Typography
-                display={{ xs: "block", md: "none", lg: "block" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                display={{ xs: "block", md: "none" }}
+                fontSize={{ xs: "16px", sm: "24px" }}
                 color={"white"}
                 sx={{mb: 2}}
               >
@@ -312,9 +335,17 @@ export const HeroLayout = () => {
               </Typography>
               <Typography
                 display={{ xs: "none", md: "block", lg: "none" }}
-                fontSize={{ xs: "16px", sm: "24px", md: "30px" }}
+                fontSize={{ md: "30px" }}
                 color={"white"}
                 sx={{mb: 2, minHeight: "140px"}}
+              >
+                コメント、いいね、シェアでつながる
+              </Typography>
+              <Typography
+                display={{ xs: "none", lg: "block" }}
+                fontSize={{ lg: "36px" }}
+                color={"white"}
+                sx={{mb: 2, minHeight: "110px"}}
               >
                 コメント、いいね、シェアでつながる
               </Typography>

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -13,8 +13,8 @@ const styleForHero = {
   backgroundSize: 'cover',
   backgroundRepeat: 'no-repeat',
   backgroundPosition: 'center',
-  backgroundColor: "rgba(255,255,255,0.4)",
-  // backgroundBlendMode: "lighten"
+  backgroundColor: "rgba(255,255,255,0.2)",
+  backgroundBlendMode: "lighten"
 };
 
 export const FadeInText = ({ text, delay, duration }) => {
@@ -53,18 +53,51 @@ export const HeroLayout = () => {
 
   return (
     <>
-      <Box sx={{height: "100%", display: "flex", alignItems: "center", position: "relative"}} bgcolor={"primary.dark"}  >
-        <Box sx={{mx: 20}} >
-          <Typography variant="h1" color={"white"} sx={{mb: 1}} >
+      <Box
+        sx={{
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          position: "relative"
+        }}
+        bgcolor={"primary.dark"}
+      >
+        <Box sx={{mx: { xs: 2, sm:10, md: 20}}} >
+          <Typography
+            color={"white"}
+            sx={{
+              mb: 1,
+              typography: {
+                xs: "h3",
+                sm: "h1"
+              }
+            }}
+          >
             <FadeInText text={"BackHacker."} delay={300} />
           </Typography>
-          <Typography variant="h4" color={"white"} sx={{mb: 7}} >
+          <Typography
+            color={"white"}
+            sx={{
+              mb: 7,
+              typography: {
+                xs: "h6",
+                sm: "h4"
+              },
+              fontWeight: {
+                xs: "none"
+              }
+            }}
+          >
             <FadeInText text={"バーチャル旅行に出かけよう"} delay={600} />
           </Typography>
           <FadeInText
             text={
               <Button onClick={handleClick} variant="outlined" color="info" sx={{mx: 1, mb: 3}} size="large" >
-                <Typography fontSize={"20px"} >🌏 旅を始める</Typography>
+                <Typography
+                  fontSize={ {xs: "12px", sm: "20px", md: "20px"}}
+                >
+                  🌏 旅を始める
+                </Typography>
               </Button>
             }
             delay={1100}
@@ -82,63 +115,224 @@ export const HeroLayout = () => {
       <Box
         ref={scrollToMidRef}
         sx={{
-          height: "100%",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          position: "relative"
+          position: "relative",
         }}
         bgcolor={"primary.dark"}
         style={styleForHero}
       >
-        <Box sx={{width: "60%"}} >
-          <Typography fontSize={"60px"} color={"black"} fontWeight={"bold"} sx={{mb: 3}}>ひらけPC。行くぞ海外。</Typography>
-          <Typography fontSize={"24px"} color={"black"} >BackHacker.は、「自宅にいながらPC1台でバックパッカー」をコンセプトとした、バーチャル旅行好きのためのエンタメアプリです。</Typography>
-          <Typography fontSize={"24px"} color={"black"} >地図を見ながら、世界中の国や都市の街歩き動画を楽しんで、旅行気分を味わうことができます。</Typography>
-          <Typography fontSize={"24px"} color={"black"} sx={{mt: 3}} >PC1台で、知らない土地に気軽にトリップしてみませんか？</Typography>
-        </Box>
         <Box
-          sx={{position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)'}}
+          sx={{width: {xs: "90%", sm: "80%"} }}
+        >
+          <Typography
+            fontSize={{ xs: "24px", sm: "50px", md: "60px" }}
+            color={"black"}
+            fontWeight={"bold"}
+            sx={{mb: 3}}
+          >
+            ひらけPC。行くぞ海外。
+          </Typography>
+          <Typography
+            fontSize={{ xs: "16px", sm: "24px"}}
+            color={"black"}
+          >
+            BackHacker.は、「自宅にいながらPC1台でバックパッカー」をコンセプトとした、バーチャル旅行好きのためのエンタメアプリです。</Typography>
+          <Typography
+            fontSize={{ xs: "16px", sm: "24px"}}
+            color={"black"}
+          >
+            地図を見ながら、世界中の国や都市の街歩き動画を楽しんで、旅行気分を味わうことができます。
+          </Typography>
+          <Typography
+            fontSize={{ xs: "16px", sm: "24px"}}
+            color={"black"}
+            sx={{mt: 3}}
+          >
+            PC1台で、知らない土地に気軽にトリップしてみませんか？
+          </Typography>
+        </Box>
+
+        {/* スクロールボタン */}
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 16, left: '50%',
+            transform: 'translateX(-50%)',
+          }}
           onClick={scrollToBottom}
         >
-          <Button color="primary" variant="outlined">
-            <FadeInText text={"BackHacker.でできること"} delay={2200} />
+          <Button
+            color="secondary"
+            variant={{ xs: "outlined", sm: "contained" }}
+            sx={{py: 1}}
+          >
+            <Typography
+              fontSize="16px"
+              fontWeight="bold"
+              display={{ xs: "none", sm: "block" }}
+            >
+              BackHacker.でできること
+            </Typography>
+            <ExpandMoreIcon display={{ xs: "block", sm: "none" }} />
           </Button>
         </Box>
       </Box>
+
       <Box
         sx={{
-          height: "calc(100vh - 2.5rem)",
+          minHeight: { sm: "calc(100vh - 4rem)", md: "calc(100vh - 2.5rem)" },
           display: "flex",
           flexDirection: "column",
           text: "center",
-          alignItems: "center"
+          alignItems: "center",
+          px: { xs: 1 },
+          pb: { xs: 2, sm: 1 }
         }}
         bgcolor={"primary.dark"}
         ref={scrollToBottomRef}
       >
-        <Typography fontSize={"32px"} color={"white"} sx={{pt: 10}}>BackHacker.でできること</Typography>
-        <Box sx={{display: "flex", height: "50vh", alignItems: "center"}} >
-          <Grid container spacing={5} style={{ width: '80%', margin: '0 auto' }}>
-            <Grid item xs={4} display={"flex"} flexDirection={"column"} justifyContent={"center"} alignItems={"flex-start"}>
+        <Typography
+          fontSize={{ xs: "20px", sm: "32px" }}
+          color={"white"}
+          sx={{pt: { xs: 2, sm: 8, md: 5 }}}
+        >
+          BackHacker.でできること
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            height: { xs: "100%", md: "50vh" },
+            flexDirection: { xs: "row", sm: "column" },
+            alignItems: "center",
+            justifyContent: "center", // 追加
+            mt: { xs: 4, sm: 8 }
+          }}
+        >
+          <Grid
+            container
+            spacing={{ xs: 1, sm: 3, md: 3 }}
+            sx={{
+              flexDirection: { xs: "column", sm: "row" },
+              width: { xs: "100%", sm: '80%' },
+              mb: { xs: 0, sm: 1 },
+              justifyContent: "center", // 追加
+              alignItems: "flex-start" // 追加
+            }}
+          >
+            <Grid
+              item
+              xs={12}
+              md={4}
+              display={"flex"}
+              flexDirection={"column"}
+              justifyContent={"center"}
+              alignItems={"flex-start"}
+              sx={{mb: { xs: 3 }}}
+            >
               <OndemandVideoIcon fontSize="large" color="secondary"/>
-              <Typography fontSize="36px" color={"white"} sx={{mb: 2}} >世界中の街の動画を楽しむ</Typography>
-              <Typography fontSize="16px" color={"white"} >地図上をクリックして、<span>スポット</span>(気になる場所)を投稿してみよう！世界中どこでも、街の様子がわかる動画を自動で探します🤖動画を見て旅行気分を味わおう！</Typography>
+              <Typography
+                display={{ xs: "block", md: "none" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                color={"white"}
+                sx={{mb: 2}}
+              >
+                世界中の街の動画を楽しむ
+              </Typography>
+              <Typography
+                display={{ xs: "none", md: "block" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                color={"white"}
+                sx={{mb: 2, minHeight: "180px"}}
+              >
+                世界中の街の動画を楽しむ
+              </Typography>
+              <Typography
+                fontSize={{ xs: "12px", sm: "16px" }}
+                color={"white"}
+              >
+                地図上をクリックして、<span>スポット</span>(気になる場所)を投稿してみよう！世界中どこでも、街の様子がわかる動画を自動で探します🤖動画を見て旅行気分を味わおう！
+              </Typography>
             </Grid>
-            <Grid item xs={4} display={"flex"} flexDirection={"column"} justifyContent={"center"} alignItems={"flex-start"}>
+            <Grid
+              item
+              xs={12}
+              md={4}
+              display={"flex"}
+              flexDirection={"column"}
+              justifyContent={"center"}
+              alignItems={"flex-start"}
+              sx={{mb: { xs: 3 }}}
+            >
               <GroupsIcon fontSize="large" color="secondary"/>
-              <Typography fontSize="36px" color={"white"} sx={{mb: 2}} >みんなの投稿したスポットを見にいく</Typography>
-              <Typography fontSize="16px" color={"white"} >みんなの投稿したスポットを見てみよう！旅行で訪れた思い出の場所、地元のおすすめスポット、地図から見つけたヘンなところ？なんでもアリ！思い思いのスポットを巡ってみて✨</Typography>
+              <Typography
+                display={{ xs: "block", md: "none" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                color={"white"}
+                sx={{mb: 2}}
+              >
+                みんなの投稿したスポットを見にいく
+              </Typography>
+              <Typography
+                display={{ xs: "none", md: "block" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                color={"white"}
+                sx={{mb: 2, minHeight: "180px"}}
+              >
+                みんなの投稿したスポットを見にいく
+              </Typography>
+              <Typography
+                fontSize={{ xs: "12px", sm: "16px" }}
+                color={"white"}
+              >
+                みんなの投稿したスポットを見てみよう！旅行で訪れた思い出の場所、地元のおすすめスポット、地図から見つけたヘンなところ？なんでもアリ！思い思いのスポットを巡ってみて✨
+              </Typography>
             </Grid>
-            <Grid item xs={4} display={"flex"} flexDirection={"column"} justifyContent={"center"} alignItems={"flex-start"}>
+            <Grid
+              item
+              xs={12}
+              md={4}
+              display={"flex"}
+              flexDirection={"column"}
+              justifyContent={"center"}
+              alignItems={"flex-start"}
+              sx={{mb: { xs: 3 }}}
+            >
               <ThumbUpIcon fontSize="large" color="secondary"/>
-              <Typography fontSize="36px" color={"white"} sx={{mb: 2}} >コメント、いいね、シェアでつながる</Typography>
-              <Typography fontSize="16px" color={"white"} >気に入った投稿にはいいね👍とコメントして交流しよう！さらに自分の投稿したスポットをSNSでシェアすれば、みんなが楽しんでくれるかも？</Typography>
+              <Typography
+                display={{ xs: "block", md: "none" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                color={"white"}
+                sx={{mb: 2}}
+              >
+                コメント、いいね、シェアでつながる
+              </Typography>
+              <Typography
+                display={{ xs: "none", md: "block" }}
+                fontSize={{ xs: "16px", sm: "24px", md: "36px" }}
+                color={"white"}
+                sx={{mb: 2, minHeight: "180px"}}
+              >
+                コメント、いいね、シェアでつながる
+              </Typography>
+              <Typography
+                fontSize={{ xs: "12px", sm: "16px" }}
+                color={"white"} >気に入った投稿にはいいね👍とコメントして交流しよう！さらに自分の投稿したスポットをSNSでシェアすれば、みんなが楽しんでくれるかも？</Typography>
             </Grid>
           </Grid>
         </Box>
-        <Button onClick={handleClick} variant="contained" color="info" sx={{mt: 8, py: 2, px: 6}} size="large" ><Typography fontSize={"20px"} >BackHacker.で旅を始める 🌏</Typography></Button>
+        <Button
+          onClick={handleClick}
+          variant="contained"
+          color="info"
+          sx={{mt: { xs: 3, sm: 2, md: 3 }, py: { xs: 1, sm: 2 }, px: { xs: 2,  md: 6 }}}
+        >
+          <Typography fontSize={{ xs: "16px", md: "20px" }} >
+            遊んでみる 🌏
+          </Typography>
+        </Button>
       </Box>
     </>
   )

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -6,7 +6,7 @@ import { Footer } from "../Footer/Footer";
 
 export const MainLayout = () => {
   const location = useLocation();
-  const hideFooter = location.pathname === "/map";
+  const hideFooter = location.pathname === "/map" || location.pathname === "/spots";
 
   return (
     <Box sx={{height: "calc(100vh - 64px)", width: "100%"}}>

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -4,7 +4,6 @@ import { UserProfile } from "../../features/users/components/UserProfile"
 import { useParams } from "react-router-dom";
 import { getUsers } from "../../features/users/api/getUsers";
 import { SpotListTab } from "../../features/users/components/SpotListTab";
-import { TermsOfService } from "../../features/terms_of_services/components/TermsOfService";
 
 export const UserLayout = () => {
   const { loadSpots } = useSpotsContext();

--- a/src/features/privacy_policy/components/PrivacyPolicy.jsx
+++ b/src/features/privacy_policy/components/PrivacyPolicy.jsx
@@ -16,9 +16,17 @@ export const PrivacyPolicy = () => {
 
   return (
     <>
-      <Box sx={{display: "flex", flexDirection: "column", justifyContent: "center", px: 20, py: 2 }} >
-        <Box display="flex" justifyContent="center" sx={{pb: 5}}>
-          <Typography variant="h4" fontWeight="bold" >プライバシーポリシー</Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          px: { xs: 3, sm: 10, md: 20 },
+          py: 2
+        }}
+      >
+        <Box display="flex" justifyContent="center" sx={{pb: { xs: 2, sm: 5 }}}>
+          <Typography fontSize={{xs: "20px", sm: "40px"}} fontWeight="bold" >プライバシーポリシー</Typography>
         </Box>
         <Box sx={{display: "flex", flexDirection: "column", justifyContent: "center", gap: 5}} >
           <Box>

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -16,7 +16,10 @@ const style = {
   textAlign: 'center',
   alignItems: "center",
   margin: "0 auto",
-  paddingTop: "30px"
+  paddingTop: {
+    xs: 2,
+    sm: 4
+  }
 }
 const searchFailureModal = {
   title: "動画が見つかりませんでした...",
@@ -80,7 +83,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
 
   return (
     latLng ?
-      <Box style={style} >
+      <Box sx={style} >
         <MessageModal
           open={searchFailureModalOpen}
           setOpen={setSearchFailureModalOpen}
@@ -90,13 +93,14 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
           button={"close"}
         />
         <form onSubmit={handleSpotPost} >
-          <Typography variant='h5' fontSize={"24px"}>
+          <Typography variant='h5' fontSize={{xs: "16px", sm: "24px"}}>
             <RoomTwoToneIcon />スポット新規投稿
           </Typography>
           <TextField
             id="spotName"
             label="スポット名"
             fullWidth
+            size="small"
             variant="outlined"
             color="info"
             margin="normal"
@@ -110,6 +114,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
           <TextField
             id="outlined-multiline-static"
             label="説明"
+            size="small"
             fullWidth
             multiline
             rows={2}
@@ -121,7 +126,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
             value={spotDescription}
             onChange={(e) => setSpotDescription(e.target.value)}
           />
-          <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>
+          {/* <Box sx={{display: "flex", flexDirection: "row", alignItems: "center", textAlign: "center", justifyContent: "center", pb: 1, pt: 1}}>
             <Typography>動画を自動で取得する</Typography>
             <Switch
               {...label}
@@ -130,7 +135,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
               checked={isAutoFetchEnabled}
               onChange={() => setIsAutoFetchEnabled(!isAutoFetchEnabled)}
             />
-          </Box>
+          </Box> */}
           <Box sx={{pb: 3}}>
             {isAutoFetchEnabled ? (
               <>
@@ -144,29 +149,32 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
               </>
             )}
           </Box>
-          <Box >
-            <>
-              <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
-              <Button
-                type='submit'
-                color='success'
-                variant='contained'
-                display={"flex"}
-                sx={{width: "150px"}}
-                disabled={isDisabled}
-              >
-                投稿する
-              </Button>
-            </>
+          <Box sx={{pb: { xs: 3, sm: 0 }}} >
+            <Button variant='text' onClick={handleCancelClick} >キャンセル</Button>
+            <Button
+              type='submit'
+              color='success'
+              variant='contained'
+              display={"flex"}
+              sx={{width: "150px"}}
+              disabled={isDisabled}
+            >
+              投稿する
+            </Button>
           </Box>
         </form>
       </Box>
     :
-      <Box style={style} >
-        <Typography variant='h5' fontSize={"24px"}>
+      <Box sx={style} >
+        <Typography variant='h5' fontSize={{xs: "16px", sm: "24px"}} >
           <RoomTwoToneIcon />スポット新規投稿
         </Typography>
-        <Alert severity="info" variant="filled" sx={{mt: 5}}>地図上をクリックして、投稿する地点を指定してください</Alert>
+        <Alert
+          severity="info"
+          variant="filled"
+          sx={{mt: { xs: 1, sm: 5} }}>
+          地図上をクリックして、投稿する地点を指定してください
+        </Alert>
       </Box>
   )
 }

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -15,11 +15,7 @@ const style = {
   width: '90%',
   textAlign: 'center',
   alignItems: "center",
-  margin: "0 auto",
-  paddingTop: {
-    xs: 2,
-    sm: 4
-  }
+  margin: "0 auto"
 }
 const searchFailureModal = {
   title: "動画が見つかりませんでした...",

--- a/src/features/spots/components/SpotCard.jsx
+++ b/src/features/spots/components/SpotCard.jsx
@@ -13,7 +13,7 @@ export const SpotCard = ({ spots, text }) => {
       <Grid container spacing={2} style={{ width: '100%', margin: '0 auto' }} >
         {spots.length > 0 ? (
           spots.map((spot) => (
-            <Grid item xs={4} >
+            <Grid item xs={12} sm={6} md={4} >
               <Link
                 to={`/spots/${spot.id}`}
                 style={{color: "inherit", textDecoration: "none"}}

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -35,35 +35,51 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
             display={"flex"}
             flexDirection={"row"}
             justifyContent={"space-between"}
-            sx={{px: 2, mt: 2}}
+            sx={{px: { xs: 0, sm: 2 }, mt: 2}}
           >
-            <Box >
-              <Button
-                component={Link}
-                to={`/users/${selectedSpot.user.id}`}
-                sx={{
-                  color: "inherit",
-                  textDecoration: "none",
-                  display: "flex",
-                  flexDirection: "row",
-                  justifyContent: "left",
-                  mb: 2,
-                  width: "100%"
-                }}
+            <Box width="100%">
+              <Box display="flex" flexDirection="row" justifyContent="space-between" >
+                <Button
+                  component={Link}
+                  to={`/users/${selectedSpot.user.id}`}
+                  sx={{
+                    color: "inherit",
+                    textDecoration: "none",
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "left",
+                    mb: { xs: 1, sm: 2 },
+                    width: "100%"
+                  }}
+                >
+                  <Avatar
+                    src={selectedSpot.user.avatar}
+                    sx={{
+                      mr: 2,
+                      width: { xs: 24, sm: 40 },
+                      height: { xs: 24, sm: 40 }
+                    }}
+                  >
+                  </Avatar>
+                  <Typography fontSize={{ xs: "16px", sm: "20px" }} >{selectedSpot.user.name}</Typography>
+                </Button>
+                { userId === selectedSpot.user.id &&
+                  <ConfigButton
+                    currentUser={currentUser}
+                    selectedSpot={selectedSpot}
+                    setEditing={setEditing}
+                    handleModalClose={handleClose}
+                  />
+                }
+              </Box>
+              <Typography
+                fontSize={{ xs: "16px", sm: "20px" }}
+                fontWeight="bold"
+                sx={{px: { xs: 1, sm: 0 }}}
               >
-                <Avatar src={selectedSpot.user.avatar} sx={{mr: 2}} ></Avatar>
-                <Typography fontSize="20px" >{selectedSpot.user.name}</Typography>
-              </Button>
-              <Typography fontSize="20px" fontWeight="bold" >{selectedSpot.name}</Typography>
+                {selectedSpot.name}
+              </Typography>
             </Box>
-          { userId === selectedSpot.user.id &&
-            <ConfigButton
-              currentUser={currentUser}
-              selectedSpot={selectedSpot}
-              setEditing={setEditing}
-              handleModalClose={handleClose}
-            />
-          }
           </Box>
           <Box
             sx={{
@@ -100,7 +116,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
             <Box sx={{display: "flex", justifyContent: "left", alignItems: "center", width: "100%"}}>
               <Tooltip title="コメント">
                 <span>
-                  <IconButton sx={{mx: 2}} onClick={() => setCommentModalOpen(true)} ><ChatBubbleOutlineIcon /></IconButton>
+                  <IconButton sx={{ml: 1, mr: 2}} onClick={() => setCommentModalOpen(true)} ><ChatBubbleOutlineIcon /></IconButton>
                 </span>
               </Tooltip>
               <LikeButton

--- a/src/features/terms_of_services/components/TermsOfService.jsx
+++ b/src/features/terms_of_services/components/TermsOfService.jsx
@@ -16,9 +16,17 @@ export const TermsOfService = () => {
 
   return (
     <>
-      <Box sx={{display: "flex", flexDirection: "column", justifyContent: "center", px: 20, py: 2 }} >
-        <Box display="flex" justifyContent="center" sx={{pb: 5}}>
-          <Typography variant="h4" fontWeight="bold" >利用規約</Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          px: { xs: 3, sm: 10, md: 20 },
+          py: 2
+        }}
+      >
+        <Box display="flex" justifyContent="center" sx={{pb: { xs: 2, sm: 5 }}}>
+          <Typography fontSize={{xs: "20px", sm: "40px"}} fontWeight="bold" >利用規約</Typography>
         </Box>
         <Box sx={{display: "flex", flexDirection: "column", justifyContent: "center", gap: 5}} >
           <Box>

--- a/src/features/users/components/SpotListTab.jsx
+++ b/src/features/users/components/SpotListTab.jsx
@@ -44,7 +44,7 @@ function a11yProps(index) {
 }
 
 export const SpotListTab = ({ userInfo }) => {
-  const [value, setValue] = useState(0);
+  const [ value, setValue ] = useState(0);
   const { spots } = useSpotsContext();
 
   const handleChange = (event, newValue) => {
@@ -73,18 +73,18 @@ export const SpotListTab = ({ userInfo }) => {
         sx={{
           borderBottom: "none",
           borderColor: 'devider',
-          width: '40%',
+          width: {xs: '90%', sm: '40%'},
           display: "flex",
           justifyContent: "center"
         }}
       >
-        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example" >
-          <Tab label="投稿したスポット" {...a11yProps(0)} color='"primary.light'/>
-          <Tab label="いいねしたスポット" {...a11yProps(1)} color='"primary.light'/>
+        <Tabs value={value} onChange={handleChange} >
+          <Tab label="投稿したスポット" {...a11yProps(0)} color='"primary.light' sx={{fontSize: {xs: "12px", sm: "14px"}}}/>
+          <Tab label="いいねしたスポット" {...a11yProps(1)} color='"primary.light' sx={{fontSize: {xs: "12px", sm: "14px"}}}/>
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
-        <Box width={"70vw"}>
+        <Box width={{ xs: "90vw", sm: "70vw" }}>
           {!spots && <Spinner />}
           <SpotCard spots={userPostedSpots()} text={"投稿"} />
         </Box>

--- a/src/features/users/components/UserProfile.jsx
+++ b/src/features/users/components/UserProfile.jsx
@@ -31,12 +31,12 @@ export const UserProfile = ({ userInfo }) => {
         <Box sx={{display: "flex", justifyContent: "space-between", minWidth: "30%", maxWidth: "60%", py: 2}}>
           {!editing ?
             <Box sx={{display: "flex", flexDirection: "row", alignItems: "end"}} >
-                <Avatar src={updatedUser && updatedUser !== null ? updatedUser.avatar : userInfo.avatar} sx={{mr: 3, width: 100, height: 100}}></Avatar>
-                <Typography fontSize="30px" >{updatedUser && updatedUser !== null ? updatedUser.name : userInfo.name}</Typography>
+                <Avatar src={updatedUser && updatedUser !== null ? updatedUser.avatar : userInfo.avatar} sx={{mr: 3, width: { xs: 42, sm: 100 }, height: {xs: 42, sm: 100 }}}></Avatar>
+                <Typography fontSize={{xs: "20px", sm: "30px"}} fontWeight="bold" >{updatedUser && updatedUser !== null ? updatedUser.name : userInfo.name}</Typography>
             </Box>
           :
-          <Box sx={{display: "flex", flexDirection: "row", alignItems: "end"}} >
-            <Avatar src={userInfo.avatar} sx={{mr: 3, width: 100, height: 100}}></Avatar>
+          <Box sx={{display: "flex", flexDirection: "row", alignItems: "center"}} >
+            {/* <Avatar src={userInfo.avatar} sx={{mr: 3, width: { xs: 42, sm: 100 }, height: {xs: 42, sm: 100 }}} ></Avatar> */}
               <form onSubmit={handleSubmitName}>
                 <Box display="flex" flexDirection="row">
                   <Box bgcolor={"white"}>
@@ -44,7 +44,7 @@ export const UserProfile = ({ userInfo }) => {
                       variant="outlined"
                       color="info"
                       defaultValue={`${updatedUser && updatedUser !== null ? updatedUser.name : userInfo.name}`}
-                      sx={{width: "300px"}}
+                      sx={{width: {xs: "150px", sm: "300px"}}}
                       onChange={handleEditName}
                     >
                     </TextField>


### PR DESCRIPTION
## 概要
- 各ページのレスポンシブ設定を追加しました。
  - スマートフォンサイズ(`xs: 0px`)
  - タブレットサイズ(`sm: 600px`)
  - PCサイズ(`md: 900px`)

## 実施したこと
- [x] ヘッダーのレスポンシブ対応
- [x] フッターのレスポンシブ対応
- [x] トップページをレスポンシブ対応
- [x] スポット新規投稿ページのレスポンシブ対応
- [x] スポット詳細ページのモーダルのレスポンシブ対応
- [x] ユーザー情報ページのレスポンシブ対応
- [x] 利用規約ページのレスポンシブ対応

## 追加Issue
- スポット投稿完了時のモーダルの高さを調整可能にする
- 画面高さが不足する場合、ヒーローページの文字とスクロールボタンが画面からはみ出してしまう不具合の対応
  - iPhone 15 PRO MAX (430px × 932px)など、縦長のスマートフォンを横向きにした場合に発生します
[画像(ヒーローのレスポンシブ)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/1341854c-103c-4174-ab6d-fc5264ca2e01)
[画像(スポット投稿完了モーダルのレスポンシブ)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f4515ae4-fc7c-4a51-b572-93aa42121e1e)
