### PR TITLE
退会機能の修正

### DIFF
--- a/src/components/Elements/Buttons/UserConfigButton.jsx
+++ b/src/components/Elements/Buttons/UserConfigButton.jsx
@@ -62,9 +62,7 @@ export const UserConfigButton = ({ setEditing }) => {
           <LogOutButton />
         </MenuItem>
         <MenuItem onClick={handleClose} >
-          <Button  >
-            <WithdrawalButton />
-          </Button>
+          <WithdrawalButton />
         </MenuItem>
       </Menu>
     </div>

--- a/src/components/Elements/Buttons/UserConfigButton.jsx
+++ b/src/components/Elements/Buttons/UserConfigButton.jsx
@@ -2,20 +2,25 @@ import React, { useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Fade from '@mui/material/Fade';
-import { Box, Button, IconButton, Typography } from '@mui/material';
+import { Box, IconButton, Typography } from '@mui/material';
 import { LogOutButton } from '../../../features/auth/components/LogOutButton';
-import { WithdrawalButton } from '../../../features/users/components/WithdrawalButton';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import EditIcon from '@mui/icons-material/Edit';
+import WarningIcon from '@mui/icons-material/Warning';
+import MessageModal from '../Modals/MessageModal';
 
 export const UserConfigButton = ({ setEditing }) => {
   const [anchorEl, setAnchorEl] = useState(null);
-  const open = Boolean(anchorEl);
+  const [ modalOpen, setModalOpen ] = useState(false);
+
+  const menuOpen = Boolean(anchorEl);
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = () => {
+  const handleClose = async () => {
+    if (modalOpen) return;
+
     setAnchorEl(null);
   };
 
@@ -24,13 +29,30 @@ export const UserConfigButton = ({ setEditing }) => {
     setEditing(true);
   };
 
+  const handleWithdrawalClick = () => {
+    setModalOpen(true);
+  }
+
+  const modalInfo = {
+    body: "これまで投稿したスポット、いいね、コメントはすべて削除されます。退会しますか？",
+    button: "withdrawal"
+  };
+
   return (
     <div>
+      <MessageModal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        title={modalInfo.title}
+        body={modalInfo.body}
+        icon={modalInfo.icon}
+        button={modalInfo.button}
+      />
       <IconButton
         id="fade-button"
-        aria-controls={open ? 'fade-menu' : undefined}
+        aria-controls={menuOpen ? 'fade-menu' : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={menuOpen ? 'true' : undefined}
         onClick={handleClick}
         color='primary'
       >
@@ -42,7 +64,7 @@ export const UserConfigButton = ({ setEditing }) => {
           'aria-labelledby': 'fade-button',
         }}
         anchorEl={anchorEl}
-        open={open}
+        open={menuOpen}
         onClose={handleClose}
         TransitionComponent={Fade}
       >
@@ -61,8 +83,17 @@ export const UserConfigButton = ({ setEditing }) => {
         <MenuItem onClick={handleClose} >
           <LogOutButton />
         </MenuItem>
-        <MenuItem onClick={handleClose} >
-          <WithdrawalButton />
+        <MenuItem onClick={handleWithdrawalClick} >
+          <Box
+            sx={{p: 0, m: 0}}
+            display={"flex"}
+            flexDirection={"row"}
+          >
+            <WarningIcon fontSize="small" sx={{mr: 1}} color='error' />
+            <Typography color='error' >
+              退会する
+            </Typography>
+          </Box>
         </MenuItem>
       </Menu>
     </div>

--- a/src/components/Elements/Buttons/UserConfigButton.jsx
+++ b/src/components/Elements/Buttons/UserConfigButton.jsx
@@ -62,7 +62,7 @@ export const UserConfigButton = ({ setEditing }) => {
           <LogOutButton />
         </MenuItem>
         <MenuItem onClick={handleClose} >
-          <Button disabled >
+          <Button  >
             <WithdrawalButton />
           </Button>
         </MenuItem>

--- a/src/components/Elements/Modals/MessageModal.jsx
+++ b/src/components/Elements/Modals/MessageModal.jsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import Modal from '@mui/material/Modal';
 import ReplayIcon from '@mui/icons-material/Replay';
 import { SignInButton } from '../../../features/auth/components/SignInButton';
+import { WithdrawalButton } from '../../../features/users/components/WithdrawalButton';
 
 const style = {
   position: 'absolute',
@@ -23,7 +24,9 @@ const style = {
 
 export default function MessageModal({open, setOpen, title, body, icon, button}) {
   const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
+  const handleClose = () => {
+    setOpen(false);
+  }
   const buttonType = button;
 
   return (
@@ -45,6 +48,20 @@ export default function MessageModal({open, setOpen, title, body, icon, button})
           <Box sx={{pt: 2}} textAlign={"center"}>
             {buttonType === "login" && <SignInButton text={"ログイン"} variant={"contained"} color={"info"} handleClose={handleClose} />}
             {buttonType === "close" && <Button variant="contained" color="info" onClick={handleClose}><ReplayIcon />別の場所を投稿する</Button>}
+            {buttonType === "withdrawal" &&
+              <Box textAlign="center">
+                <Button variant="text" sx={{mr: 2, fontWeight: "normal"}} onClick={handleClose}>戻る</Button>
+                <WithdrawalButton />
+                <Box sx={{pt: 2}} textAlign="left">
+                  <Typography fontSize="12px">
+                    ※「退会する」をクリックするとログイン画面が表示されます。
+                  </Typography>
+                  <Typography fontSize="12px">
+                    ログインすると、退会処理が完了します。
+                  </Typography>
+                </Box>
+              </Box>
+            }
           </Box>
         </Box>
       </Modal>

--- a/src/components/FlashMessages/FlashMessage.jsx
+++ b/src/components/FlashMessages/FlashMessage.jsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Snackbar from '@mui/material/Snackbar';
 import Fade from '@mui/material/Fade';
 import Slide from '@mui/material/Slide';
-import { useLocation } from 'react-router-dom';
 import { Alert } from '@mui/material';
 import { useFlashMessage } from '../../contexts/FlashMessageContext';
 
@@ -17,7 +16,7 @@ export default function FlashMessage() {
   });
   const { message, isSuccessMessage } = useFlashMessage();
 
-  useState(() => {
+  useEffect(() => {
     if (message) {
       setState({
         open: true,
@@ -54,7 +53,7 @@ export default function FlashMessage() {
           </Alert>
           :
           <Alert
-            severity="warning"
+            severity="error"
             variant="filled"
             sx={{ width: '100%' }}
           >

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -44,7 +44,7 @@ export default function Header() {
 
   const handleProfileOpen = () => {
     handleMenuClose();
-    navigate(`/users/${userId}`);
+    navigate("/profile");
   }
 
   const handleNavigate = () => {

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -4,10 +4,12 @@ import { UserProfile } from "../../features/users/components/UserProfile"
 import { useParams } from "react-router-dom";
 import { getUsers } from "../../features/users/api/getUsers";
 import { SpotListTab } from "../../features/users/components/SpotListTab";
+import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 
 export const UserLayout = () => {
   const { loadSpots } = useSpotsContext();
-  const { userId } = useParams();
+  const { userId } = useFirebaseAuth();
+  const { id } = useParams();
   const [ userInfo, setUserInfo ] = useState();
 
   useEffect(() => {
@@ -15,17 +17,26 @@ export const UserLayout = () => {
   }, []);
 
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const users = await getUsers();
-        const selectedUser = users.find(user => parseInt(user.id) === parseInt(userId))
-        setUserInfo(selectedUser);
-      } catch (error) {
-        console.error('Failed to fetch user data', error);
+
+
+      const fetchData = async () => {
+        try {
+          const users = await getUsers();
+
+          if (id) {
+            const selectedUser = users.find(user => parseInt(user.id) === parseInt(id))
+            setUserInfo(selectedUser);
+          } else {
+            const selectedUser = users.find(user => parseInt(user.id) === parseInt(userId))
+            setUserInfo(selectedUser);
+          }
+        } catch (error) {
+          console.error('Failed to fetch user data', error);
+        }
       }
-    }
-    fetchData();
-  }, [userId])
+      fetchData();
+
+  }, [userId, userId])
 
   if (!userInfo) {
     return <div></div>;

--- a/src/components/Layout/UserLayout.jsx
+++ b/src/components/Layout/UserLayout.jsx
@@ -4,7 +4,6 @@ import { UserProfile } from "../../features/users/components/UserProfile"
 import { useParams } from "react-router-dom";
 import { getUsers } from "../../features/users/api/getUsers";
 import { SpotListTab } from "../../features/users/components/SpotListTab";
-import { TermsOfService } from "../../features/terms_of_services/components/TermsOfService";
 
 export const UserLayout = () => {
   const { loadSpots } = useSpotsContext();

--- a/src/features/auth/components/SignInButton.jsx
+++ b/src/features/auth/components/SignInButton.jsx
@@ -6,7 +6,7 @@ import { Login } from '@mui/icons-material';
 import { useFlashMessage } from '../../../contexts/FlashMessageContext';
 
 export const SignInButton = ({ text, variant, color, handleClose }) => {
-  const { loginWithGoogle } = useFirebaseAuth();
+  const { loginWithGoogle, nextOrObserver } = useFirebaseAuth();
   const { setMessage, setIsSuccessMessage } = useFlashMessage();
 
   const handleGoogleLogin = () => {
@@ -28,6 +28,7 @@ export const SignInButton = ({ text, variant, color, handleClose }) => {
           // 成功時はレスポンスデータ全体を返す
           setIsSuccessMessage(true);
           setMessage("ログインしました");
+          nextOrObserver(user);
           handleClose();
           return { success: true, data: res.data };
         } else {

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -1,5 +1,4 @@
 import { Box, Button, TextField, Typography } from "@mui/material"
-import SendIcon from '@mui/icons-material/Send';
 import { useEffect, useState } from "react";
 import { createComment } from "../api/createComment";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -39,7 +39,6 @@ export const CreateComment = ({ spotId, setIsCommentPosted, setOpen }) => {
       setInputComment("");
       setIsCommentPosted(true);
     } else {
-      console.log(result)
       setMessage(result.message);
     }
   }

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -41,7 +41,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
               <Box display="flex" flexDirection="row" justifyContent="space-between" >
                 <Button
                   component={Link}
-                  to={`/users/${selectedSpot.user.id}`}
+                  to={userId === selectedSpot.user.id ? "/profile" : `/users/${selectedSpot.user.id}`}
                   sx={{
                     color: "inherit",
                     textDecoration: "none",

--- a/src/features/users/api/deleteUser.js
+++ b/src/features/users/api/deleteUser.js
@@ -1,4 +1,5 @@
 import { axios } from '../../../lib/axios'
+import { isAxiosError } from 'axios';
 
 export const deleteUser = async ( currentUser ) => {
   const token = await currentUser?.getIdToken()
@@ -12,14 +13,18 @@ export const deleteUser = async ( currentUser ) => {
 
   try {
     const res = await axios.delete(`/api/v1/users/${currentUser.uid}`, config);
-    return res.data.message;
-  } catch (err) {
-    let message;
-    if (axios.isAxiosError(err) && err.response) {
-      console.error(err.response.data.message);
+    if (res.status === 200) {
+      // 成功時はレスポンスデータ全体を返す
+      return { success: true, data: res.data, message: "退会しました" };
     } else {
-      message = String(err);
-      console.error(message);
+      // ステータスコードが200以外の場合は、エラーメッセージを返す
+      throw new Error("退会できませんでした");
+    }
+  } catch (err) {
+    if (isAxiosError(err) && err.response) {
+      return { success: false, message: err.response.data.message || "エラーが発生しました" };
+    } else {
+      return { success: false, message: String(err) };
     }
   }
 }

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -1,20 +1,37 @@
 import { Box, Typography } from "@mui/material";
-import { deleteUser as deleteUserFromFirebase } from "firebase/auth";
+import {
+  deleteUser as deleteUserFromFirebase,
+  signInWithPopup,
+  GoogleAuthProvider,
+  reauthenticateWithCredential
+} from "firebase/auth";
 import { useNavigate } from "react-router-dom";
 import { deleteUser } from "../api/deleteUser";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import WarningIcon from '@mui/icons-material/Warning';
+import { auth } from "../../../lib/firebase";
 
 export const WithdrawalButton = () => {
-  const { currentUser, loginWithGoogle } = useFirebaseAuth();
-
+  const { currentUser } = useFirebaseAuth();
 
   const navigate = useNavigate();
 
   const withdrawalUser = async () => {
     if (!currentUser) return;
 
-    await loginWithGoogle();
+    // 退会するためには最近ログインしている必要があるので、ログイン処理を実行する
+    const login = async () => {
+      const provider = new GoogleAuthProvider();
+      const result = await signInWithPopup(auth, provider);
+      return result;
+    }
+
+    // ログインしたユーザーから新しい認証情報を取得し、ユーザーを再認証する
+    // see document:https://firebase.google.com/docs/auth/web/manage-users?hl=ja#re-authenticate_a_user
+    const result = await login();
+    const credential = GoogleAuthProvider.credentialFromResult(result);
+    await reauthenticateWithCredential(currentUser, credential);
+    // Firebaseからユーザーを削除後、データベースからもユーザーを削除する
     await deleteUserFromFirebase(currentUser)
     .then(() => {
       deleteUser(currentUser).then((message) => {

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -1,9 +1,9 @@
 import { Box, Typography } from "@mui/material";
-import { signInWithPopup, GoogleAuthProvider, getAuth } from "firebase/auth";
 import { deleteUser as deleteUserFromFirebase } from "firebase/auth";
 import { useNavigate } from "react-router-dom";
 import { deleteUser } from "../api/deleteUser";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
+import WarningIcon from '@mui/icons-material/Warning';
 
 export const WithdrawalButton = () => {
   const { currentUser, loginWithGoogle } = useFirebaseAuth();
@@ -33,9 +33,11 @@ export const WithdrawalButton = () => {
       sx={{p: 0, m: 0}}
       display={"flex"}
       flexDirection={"row"}
+      alignItems={"center"}
       onClick={withdrawalUser}
     >
-      <Typography color={"warning"}>退会する</Typography>
+      <WarningIcon fontSize="small" color="error" sx={{mr: 1}} />
+      <Typography color={"error"}>退会する</Typography>
     </Box>
   )
 }

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import {
   deleteUser as deleteUserFromFirebase,
   signInWithPopup,
@@ -10,9 +10,11 @@ import { deleteUser } from "../api/deleteUser";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import WarningIcon from '@mui/icons-material/Warning';
 import { auth } from "../../../lib/firebase";
+import { useFlashMessage } from "../../../contexts/FlashMessageContext";
 
 export const WithdrawalButton = () => {
   const { currentUser } = useFirebaseAuth();
+  const { message, setMessage, setIsSuccessMessage } = useFlashMessage();
 
   const navigate = useNavigate();
 
@@ -34,8 +36,14 @@ export const WithdrawalButton = () => {
     // Firebaseからユーザーを削除後、データベースからもユーザーを削除する
     await deleteUserFromFirebase(currentUser)
     .then(() => {
-      deleteUser(currentUser).then((message) => {
-        navigate("/", { state: { message: message } });
+      deleteUser(currentUser).then((res) => {
+        if (res.success) {
+          setMessage(res.message);
+          setIsSuccessMessage(true);
+          navigate("/", { state: { message: message } });
+        } else {
+          setMessage(res.message);
+        }
       }).catch ((error) => {
         return {
           isSuccess: false,
@@ -46,15 +54,17 @@ export const WithdrawalButton = () => {
   };
 
   return (
-    <Box
-      sx={{p: 0, m: 0}}
+    <Button
+      sx={{p: 1, m: 0}}
       display={"flex"}
       flexDirection={"row"}
       alignItems={"center"}
+      variant="outlined"
+      color="error"
       onClick={withdrawalUser}
     >
       <WarningIcon fontSize="small" color="error" sx={{mr: 1}} />
       <Typography color={"error"}>退会する</Typography>
-    </Box>
+    </Button>
   )
 }

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -1,60 +1,40 @@
 import { Box, Typography } from "@mui/material";
-import { signInWithPopup, getAuth, GoogleAuthProvider, reauthenticateWithCredential } from "firebase/auth";
+import { signInWithPopup, GoogleAuthProvider, getAuth } from "firebase/auth";
 import { deleteUser as deleteUserFromFirebase } from "firebase/auth";
-import { doc, deleteDoc } from "firebase/firestore"
-import { db } from "../../../lib/firebase";
 import { useNavigate } from "react-router-dom";
 import { deleteUser } from "../api/deleteUser";
+import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 
 export const WithdrawalButton = () => {
+  const { currentUser, loginWithGoogle } = useFirebaseAuth();
+
+
   const navigate = useNavigate();
 
-  const withdrawalUser = () => {
-    const login = () => {
-      const provider = new GoogleAuthProvider();
-      return signInWithPopup(auth, provider);
-    };
+  const withdrawalUser = async () => {
+    // const auth = getAuth();
 
-    const auth = getAuth();
-    const currentUser = auth.currentUser;
+    // const login = async () => {
+    //   const provider = new GoogleAuthProvider();
+      // const res = signInWithPopup(auth, provider);
+      // console.log("loginのres", res)
+      // return res;
+    // };
 
-    if (currentUser) {
-      login().then((result) => {
-        const credential = GoogleAuthProvider.credentialFromResult(result);
-        reauthenticateWithCredential(currentUser, credential)
-        .then(() => {
-          deleteUserFromFirebase(currentUser)
-          .then(() => {
-            // if (currentUser?.id) {
-              deleteDoc(doc(db, "users", currentUser.id));
-            // }
-            deleteUser(currentUser).then((message) => {
-              navigate("/", { state: { message: message } });
-            }).catch ((error) => {
-              return {
-                isSuccess: false,
-                errorMessage: "アカウントの削除に失敗しました",
-              };
-            })
-          })
-          .catch((error) => {
-            // An error ocurred
-            return {
-              isSuccess: false,
-              errorMessage: "アカウントの削除に失敗しました",
-            };
-          });
-        })
-        .catch((error) => {
-          // An error ocurred
-          return {
-            isSuccess: false,
-            errorMessage: "エラーが発生しました",
-          };
-        });
-      });
-    }
-  }
+    if (!currentUser) return;
+    await loginWithGoogle();
+    await deleteUserFromFirebase(currentUser)
+    .then(() => {
+      deleteUser(currentUser).then((message) => {
+        navigate("/", { state: { message: message } });
+      }).catch ((error) => {
+        return {
+          isSuccess: false,
+          errorMessage: "アカウントの削除に失敗しました",
+        };
+      })
+    })
+  };
 
   return (
     <Box

--- a/src/features/users/components/WithdrawalButton.jsx
+++ b/src/features/users/components/WithdrawalButton.jsx
@@ -12,16 +12,8 @@ export const WithdrawalButton = () => {
   const navigate = useNavigate();
 
   const withdrawalUser = async () => {
-    // const auth = getAuth();
-
-    // const login = async () => {
-    //   const provider = new GoogleAuthProvider();
-      // const res = signInWithPopup(auth, provider);
-      // console.log("loginのres", res)
-      // return res;
-    // };
-
     if (!currentUser) return;
+
     await loginWithGoogle();
     await deleteUserFromFirebase(currentUser)
     .then(() => {

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -21,7 +21,6 @@ export const useFirebaseAuth = () => {
     const result = await signInWithPopup(auth, provider);
 
     if (result) {
-      console.log("ログインのresult.userは", result.user)
       await nextOrObserver(result.user);
       return result.user;
     }
@@ -42,10 +41,8 @@ export const useFirebaseAuth = () => {
       setLoading(false);
       setCurrentUser(null);
       setUserId(null);
-      console.log("userがいないのでreturnされました");
       return;
     }
-    console.log("userは", user);
     setCurrentUser(user);
     fetchUserData(user);
     setLoading(false);

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -7,7 +7,7 @@ import {
   signInWithPopup,
   GoogleAuthProvider,
 } from "firebase/auth";
-import { getUser } from "../features/users/api/getUser";
+import { getUsers } from "../features/users/api/getUsers";
 
 export const useFirebaseAuth = () => {
   const [currentUser, setCurrentUser] = useState();
@@ -29,6 +29,7 @@ export const useFirebaseAuth = () => {
   const clear = () => {
     setCurrentUser(null);
     setLoading(false);
+    setUserId(null);
   };
 
   const logout = async () => {
@@ -36,11 +37,11 @@ export const useFirebaseAuth = () => {
     navigate("/", { state: {message: "ログアウトしました"}});
   };
 
+  // ユーザーのログイン状態を監視する関数
   const nextOrObserver = async (user) => {
+    console.log("nextOrObserverが呼ばれました。userは", user)
     if (!user) {
-      setLoading(false);
-      setCurrentUser(null);
-      setUserId(null);
+      clear();
       return;
     }
     setCurrentUser(user);
@@ -53,16 +54,31 @@ export const useFirebaseAuth = () => {
     return unsubscribe;
   }, []);
 
-  const fetchUserData = async (currentUser) => {
-    const userData = await getUser(currentUser);
-    setUserId(userData.id)
+  // ログイン中のユーザーのidを取得する関数
+  const fetchUserData = async (user) => {
+    const usersData = await getUsers();
+    const foundUser = await usersData.find(userData => userData.uid === user.uid);
+    if (foundUser) {
+      // console.log("foundUser", foundUser);
+      // console.log("foundUser.id", foundUser.id);
+      setUserId(foundUser.id);
+    }
   }
+
+  useEffect(() => {
+    if(userId) {
+      console.log("setされたuserId", userId);
+    } else {
+      console.log("setされたuserIdはnullです");
+    }
+  },[userId]);
 
   return {
     currentUser,
     loading,
     loginWithGoogle,
     logout,
-    userId
+    userId,
+    nextOrObserver
   };
 }

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -21,9 +21,9 @@ export const useFirebaseAuth = () => {
     const result = await signInWithPopup(auth, provider);
 
     if (result) {
-      const user = result.user;
-      setCurrentUser(user);
-      return user;
+      console.log("ログインのresult.userは", result.user)
+      await nextOrObserver(result.user);
+      return result.user;
     }
   };
 
@@ -42,9 +42,12 @@ export const useFirebaseAuth = () => {
       setLoading(false);
       setCurrentUser(null);
       setUserId(null);
+      console.log("userがいないのでreturnされました");
       return;
     }
+    console.log("userは", user);
     setCurrentUser(user);
+    fetchUserData(user);
     setLoading(false);
   };
 
@@ -53,16 +56,10 @@ export const useFirebaseAuth = () => {
     return unsubscribe;
   }, []);
 
-  useEffect(() => {
-    if (currentUser) {
-      const fetchUserData = async () => {
-        const userData = await getUser(currentUser);
-        setUserId(userData.id)
-      }
-      fetchUserData();
-    }
-  }, [currentUser])
-
+  const fetchUserData = async (currentUser) => {
+    const userData = await getUser(currentUser);
+    setUserId(userData.id)
+  }
 
   return {
     currentUser,

--- a/src/hooks/useFirebaseAuth.jsx
+++ b/src/hooks/useFirebaseAuth.jsx
@@ -39,7 +39,6 @@ export const useFirebaseAuth = () => {
 
   // ユーザーのログイン状態を監視する関数
   const nextOrObserver = async (user) => {
-    console.log("nextOrObserverが呼ばれました。userは", user)
     if (!user) {
       clear();
       return;
@@ -59,19 +58,9 @@ export const useFirebaseAuth = () => {
     const usersData = await getUsers();
     const foundUser = await usersData.find(userData => userData.uid === user.uid);
     if (foundUser) {
-      // console.log("foundUser", foundUser);
-      // console.log("foundUser.id", foundUser.id);
       setUserId(foundUser.id);
     }
   }
-
-  useEffect(() => {
-    if(userId) {
-      console.log("setされたuserId", userId);
-    } else {
-      console.log("setされたuserIdはnullです");
-    }
-  },[userId]);
 
   return {
     currentUser,

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -16,7 +16,8 @@ export const AppRoutes = () => {
         <Route path="/spots" element={<CreateSpotLayout />} />
         <Route path="/map" element={<IndexSpotLayout />} />
         <Route path="spots/:spotId" element={<IndexSpotLayout />} />
-        <Route path="/users/:userId" element={<UserLayout />} />
+        <Route path="/profile" element={<UserLayout />} />
+        <Route path="/users/:id" element={<UserLayout />} />
         <Route path="/users/:userId/likes" element={<IndexLikedSpotLayout />} />
         <Route path="/terms-of-service" element={<TermsOfService />} />
         <Route path="/privacy-policy" element={<PrivacyPolicy />} />


### PR DESCRIPTION
## 概要
- 退会機能(ユーザー削除機能)において、ユーザーがデータベースから削除されない不具合があったので修正しました。
- 退会ボタンを押下後、確認モーダルを表示するようにしました。
[動画(退会ボタンと確認モーダル)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/5a60b12e-b0fc-4c5c-bee3-b0eea632a1d5)


### 不具合の原因
1. 退会ボタンを押下後、API側に`DELETE`リクエストを送信する`deleteUser`関数が呼び出されていなかったこと。
2. 会員登録(初回ログイン)の実施時、ユーザーが二重に(2人)登録されるバグが発生していた影響により、退会ボタンを押してもユーザーが1人しか削除されていなかったこと。

## 実施したこと
- [x] `deleteUser`関数が呼び出されるように修正しました。
- [x] 会員登録(初回ログイン)実施時に、ユーザーが二重に登録されないように修正しました。
- [x]  ユーザー二重登録バグ修正の影響で、ユーザー情報ページに遷移できないい不具合が発生したため、
 ユーザー情報ページのURLパスを修正しました。
- [x] 退会ボタン押下後に確認モーダルを表示するようにしました。

