### PR TITLE
画面レイアウトの修正

### DIFF
--- a/src/components/Elements/Buttons/FloatingButton.jsx
+++ b/src/components/Elements/Buttons/FloatingButton.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import { Typography } from '@mui/material';
 
 export default function FloatingButton({ text, onClick }) {
   return (
     <Box sx={{ '& > :not(style)': { m: 1 }, position: 'fixed', bottom: 16, left: '50%', transform: 'translateX(-50%)' }} onClick={onClick} >
       <Fab variant="extended" color="secondary">
-        {text}
+        <Typography fontWeight="bold" fontSize="14px" >{text}</Typography>
         <AddCircleIcon sx={{ ml: 1 }} />
       </Fab>
     </Box>

--- a/src/components/Elements/Modals/SpotDetailModal.jsx
+++ b/src/components/Elements/Modals/SpotDetailModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Dialog, DialogContent, IconButton } from '@mui/material';
+import { Box, Button, Dialog, DialogContent, IconButton, Typography } from '@mui/material';
 import { SpotDetail } from '../../../features/spots/components/SpotDetail';
 import { useNavigate } from 'react-router-dom';
 import { VideoModal } from './VideoModal';
@@ -33,10 +33,25 @@ export default function SpotDetailModal({ spotId, open, setOpen }) {
             m: 0
           }}
         >
-          <SpotDetail spotId={spotId} selectedSpot={selectedSpot} setSelectedSpot={setSelectedSpot} handleVideoClick={handleVideoClick} handleClose={handleClose} />
+          <SpotDetail
+            spotId={spotId}
+            selectedSpot={selectedSpot}
+            setSelectedSpot={setSelectedSpot}
+            handleVideoClick={handleVideoClick}
+            handleClose={handleClose}
+          />
         </DialogContent>
+          <Box display="flex" justifyContent="center" sx={{pb: 1}} >
+            <Button onClick={handleClose} >
+              <Typography color="gray" >閉じる</Typography>
+            </Button>
+          </Box>
       </Dialog>
-      <VideoModal open={videoModalOpen} setOpen={setVideoModalOpen} selectedSpot={selectedSpot} />
+      <VideoModal
+        open={videoModalOpen}
+        setOpen={setVideoModalOpen}
+        selectedSpot={selectedSpot}
+      />
     </div>
   );
 }

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -5,7 +5,6 @@ import Typography from '@mui/material/Typography';
 import Modal from '@mui/material/Modal';
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton } from '@mui/material';
-import { SignInButton } from '../../../features/auth/components/SignInButton';
 import { ShareButton } from '../Buttons/ShareButton';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/components/Elements/Modals/VideoModal.jsx
+++ b/src/components/Elements/Modals/VideoModal.jsx
@@ -23,10 +23,17 @@ export const VideoModal = ({  open, setOpen, selectedSpot }) => {
             <CloseIcon color='primary' />
           </IconButton>
         </Box>
-        <DialogContent sx={{height: "100vh", p: 0, m: 0}}>
+        <DialogContent
+          sx={{
+            height: { xs: "50vh", sm: "90vh", md: "110vh" },
+            width: { xs: "100%", sm: "100%" },
+            p: 0,
+            m: 0
+          }}
+        >
           {selectedSpot.videos && selectedSpot.videos.length > 0 && (
             selectedSpot.videos.map((video) => (
-                <Box  sx={{height: "90%", m: 0, p: 0}} textAlign={"center"}>
+              <Box sx={{height: "90%", width: "100%", m: 0, py: 1}} textAlign={"center"}>
                 <iframe
                   src={`https://www.youtube.com/embed/${video.youtube_video_id}`}
                   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
@@ -35,9 +42,9 @@ export const VideoModal = ({  open, setOpen, selectedSpot }) => {
                   height="100%"
                 >
                 </iframe>
-            </Box>
-              ))
-            )}
+              </Box>
+            ))
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/components/Layout/HeroLayout.jsx
+++ b/src/components/Layout/HeroLayout.jsx
@@ -55,10 +55,21 @@ export const HeroLayout = () => {
     <>
       <Box
         sx={{
-          height: "100%",
+          minHeight: {xs: "calc(100vh - 56px)", sm: "calc(100vh - 64px)"},
           display: "flex",
           alignItems: "center",
-          position: "relative"
+          position: "relative",
+          '@media (max-height: 440px)': {
+            position: 'relative',
+            left: 'auto',
+            transform: 'none',
+            py: 3,
+            flexDirection: "column",
+            alignItems: "left",
+            '& > *': {
+              marginLeft: '20px',
+            }
+          },
         }}
         bgcolor={"primary.dark"}
       >
@@ -104,7 +115,19 @@ export const HeroLayout = () => {
           />
         </Box>
         <Box
-          sx={{position: 'absolute', bottom: 16, left: '50%', transform: 'translateX(-50%)'}}
+          sx={{
+            position: 'absolute',
+            bottom: {xs: 60, sm: 16},
+            left: '50%',
+            transform: 'translateX(-50%)',
+            '@media (max-height: 430px)': {
+              position: 'relative',
+              left: 'auto',
+              transform: 'none',
+              pt: 3,
+              bottom: {xs: 30, sm: 16},
+            },
+          }}
           onClick={scrollToMid}
         >
           <Typography color="white" fontSize="40px" >
@@ -126,7 +149,7 @@ export const HeroLayout = () => {
         bgcolor={"primary.dark"}
       >
         <Box
-          sx={{width: {xs: "90%", sm: "80%"} }}
+          sx={{width: {xs: "90%", md: "80%"} }}
         >
           <Typography
             fontSize={{ xs: "16px", sm: "32px", md: "38px" }}
@@ -136,7 +159,7 @@ export const HeroLayout = () => {
             CONCEPT
           </Typography>
           <Typography
-            fontSize={{ xs: "24px", sm: "50px", md: "60px" }}
+            fontSize={{ xs: "24px", sm: "38px", md: "60px" }}
             color={"black"}
             fontWeight={"bold"}
             sx={{mb: 3}}
@@ -144,18 +167,18 @@ export const HeroLayout = () => {
             ひらけPC。行くぞ海外。
           </Typography>
           <Typography
-            fontSize={{ xs: "16px", sm: "24px"}}
+            fontSize={{ xs: "16px", sm: "20px", md: "24px"}}
             color={"black"}
           >
             BackHacker.は、「自宅にいながらPC1台でバックパッカー」をコンセプトとした、バーチャル旅行好きのためのエンタメアプリです。</Typography>
           <Typography
-            fontSize={{ xs: "16px", sm: "24px"}}
+            fontSize={{ xs: "16px", sm: "20px", md: "24px"}}
             color={"black"}
           >
             地図を見ながら、世界中の国や都市の街歩き動画を楽しんで、旅行気分を味わうことができます。
           </Typography>
           <Typography
-            fontSize={{ xs: "16px", sm: "24px"}}
+            fontSize={{ xs: "16px", sm: "20px", md: "24px"}}
             color={"black"}
             sx={{mt: 3}}
           >
@@ -167,8 +190,15 @@ export const HeroLayout = () => {
         <Box
           sx={{
             position: 'absolute',
-            bottom: 16, left: '50%',
+            bottom: 16,
+            left: '50%',
             transform: 'translateX(-50%)',
+            '@media (max-height: 420px)': {
+              position: 'relative',
+              left: 'auto',
+              transform: 'none',
+              pt: 3
+            },
           }}
           onClick={scrollToBottom}
         >

--- a/src/components/Layout/IndexSpotLayout.jsx
+++ b/src/components/Layout/IndexSpotLayout.jsx
@@ -62,7 +62,7 @@ export const IndexSpotLayout = () => {
             clickedMarkerId={clickedMarkerId}
           />
           <SpotDetailModal spotId={spotId} open={open} setOpen={setOpen} />
-          <FloatingButton text={"新規投稿"} onClick={handleButtonClick} />
+          <FloatingButton text={"スポットを投稿"} onClick={handleButtonClick} />
           <MessageModal
             open={loginModalOpen}
             setOpen={setLoginModalOpen}

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -9,7 +9,7 @@ export const MainLayout = () => {
   const hideFooter = location.pathname === "/map" || location.pathname === "/spots";
 
   return (
-    <Box sx={{height: "calc(100vh - 64px)", width: "100%"}}>
+    <Box sx={{height: { xs: "calc(100vh - 56px)", sm: "calc(100vh - 64px)" }}}>
       <Header />
       <Outlet />
       <FlashMessage />

--- a/src/features/comments/components/CommentIndex.jsx
+++ b/src/features/comments/components/CommentIndex.jsx
@@ -29,26 +29,58 @@ export const CommentIndex = ({ spotId, isCommentPosted }) => {
   }, [isCommentPosted, commentDeleted])
 
   return (
-    <Box sx={{px: 2}} >
+    <Box>
       {fetchedComments ?
         fetchedComments.length > 0 ?
           <>
             {fetchedComments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).map((comment) => (
-              <Box key={comment.id} sx={{pb: 1, px: 1}}>
+              <Box key={comment.id} sx={{pb: 1, px: { xs: 0, sm: 1 }}}>
                 <Box display="flex" justifyContent="space-between" >
-                  <Box sx={{display: "flex", flexDirection: "row", alignItems: "flex-end", gap: 2}} >
-                    <Button component={Link} to={`/users/${comment.user.id}`} sx={{alignItems: "flex-end",  gap: 2, pb: 0}} >
-                      <Avatar src={comment.user.avatar} />
-                      <Typography fontWeight="bold" >{comment.user.name}</Typography>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      flexDirection: "row",
+                      alignItems: "flex-end",
+                      gap: { xs: 1, sm: 2 }
+                    }}
+                  >
+                    <Button
+                      component={Link}
+                      to={`/users/${comment.user.id}`}
+                      sx={{
+                        alignItems: "flex-end",
+                        gap: { xs: 0, sm: 2 },
+                        pb: 0
+                      }}
+                    >
+                      {/* <Avatar
+                        src={comment.user.avatar}
+                        sx={{
+                          mr: { xs: 1, sm: 3 },
+                          width: { xs: 36, sm: 42 },
+                          height: {xs: 36, sm: 42 }
+                        }}
+                      /> */}
+                      <Typography fontSize={{xs: "16px", sm: "16px"}} fontWeight="bold" >
+                        {comment.user.name}
+                      </Typography>
                     </Button>
-                    <Typography fontSize="14px" >{new Date(comment.created_at).toLocaleDateString()}</Typography>
+                    <Typography fontSize={{xs: "12px", sm: "16px"}} >
+                      {new Date(comment.created_at).toLocaleDateString()}
+                    </Typography>
                   </Box>
                   {userId && comment.user_id === userId &&
-                    <DeleteComment commentId={comment.id} currentUser={currentUser} setCommentDeleted={setCommentDeleted} />
+                    <DeleteComment
+                      commentId={comment.id}
+                      currentUser={currentUser}
+                      setCommentDeleted={setCommentDeleted}
+                    />
                   }
                 </Box>
-                <Box sx={{display: "flex", justifyContent: "left", py: 1, px: 3}} >
-                  <Typography >{comment.content}</Typography>
+                <Box sx={{display: "flex", justifyContent: "left", py: 1, px: 1}} >
+                  <Typography fontSize={{xs: "14px", sm: "16px"}}  >
+                    {comment.content}
+                  </Typography>
                 </Box>
               </Box>
             ))
@@ -56,7 +88,9 @@ export const CommentIndex = ({ spotId, isCommentPosted }) => {
           </>
         :
           <Box sx={{textAlign: "center", pt: 1}} >
-            <Typography >まだコメントはありません</Typography>
+            <Typography fontSize={{xs: "14px", sm: "16px"}} >
+              まだコメントはありません
+            </Typography>
           </Box>
       :
         <></>

--- a/src/features/comments/components/CreateComment.jsx
+++ b/src/features/comments/components/CreateComment.jsx
@@ -1,8 +1,9 @@
-import { Box, Button, TextField, Typography } from "@mui/material"
+import { Alert, Box, Button, TextField, Typography } from "@mui/material"
 import { useEffect, useState } from "react";
 import { createComment } from "../api/createComment";
 import { useFirebaseAuth } from "../../../hooks/useFirebaseAuth";
 import { useFlashMessage } from "../../../contexts/FlashMessageContext";
+import { SignInButton } from "../../auth/components/SignInButton";
 
 const style = {
   display: 'flex',
@@ -50,6 +51,19 @@ export const CreateComment = ({ spotId, setIsCommentPosted, setOpen }) => {
   const handleCommentInput = (e) => {
     setInputComment(e.target.value);
     setIsCommentPosted(false);
+  }
+
+  if (!currentUser) {
+    return (
+      <Box style={style} >
+        <Alert severity="info">
+          <Typography sx={{pb: 1}} fontSize={{xs: "14px"}} >
+            コメントを投稿するにはログインしてください
+          </Typography>
+          <SignInButton text={"ログイン"} color={"info"} variant={"contained"} />
+        </Alert>
+      </Box>
+    );
   }
 
   return (

--- a/src/features/spots/components/CreateSpot.jsx
+++ b/src/features/spots/components/CreateSpot.jsx
@@ -79,7 +79,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
 
   return (
     latLng ?
-      <Box sx={style} >
+      <Box sx={style} pt={2} >
         <MessageModal
           open={searchFailureModalOpen}
           setOpen={setSearchFailureModalOpen}
@@ -89,7 +89,7 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
           button={"close"}
         />
         <form onSubmit={handleSpotPost} >
-          <Typography variant='h5' fontSize={{xs: "16px", sm: "24px"}}>
+          <Typography fontSize={{xs: "16px", sm: "20px", md: "24px"}}>
             <RoomTwoToneIcon />スポット新規投稿
           </Typography>
           <TextField
@@ -152,7 +152,10 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
               color='success'
               variant='contained'
               display={"flex"}
-              sx={{width: "150px"}}
+              sx={{
+                width: { xs: "100px", sm: "150px" },
+                ml: 1
+              }}
               disabled={isDisabled}
             >
               投稿する
@@ -161,8 +164,8 @@ export const CreateSpot = ({ latLng, setLatLng, setOpen, setCreatedSpot }) => {
         </form>
       </Box>
     :
-      <Box sx={style} >
-        <Typography variant='h5' fontSize={{xs: "16px", sm: "24px"}} >
+      <Box sx={style}  pt={2} >
+        <Typography fontSize={{xs: "16px", sm: "20px", md: "24px"}} >
           <RoomTwoToneIcon />スポット新規投稿
         </Typography>
         <Alert

--- a/src/features/spots/components/SpotCard.jsx
+++ b/src/features/spots/components/SpotCard.jsx
@@ -10,7 +10,11 @@ export const SpotCard = ({ spots, text }) => {
 
   return (
     <>
-      <Grid container spacing={2} style={{ width: '100%', margin: '0 auto' }} >
+      <Grid
+        container
+        spacing={{xs: 1, sm: 2}}
+        style={{ width: '100%', margin: '0 auto' }}
+      >
         {spots.length > 0 ? (
           spots.map((spot) => (
             <Grid item xs={12} sm={6} md={4} >

--- a/src/features/users/components/SpotListTab.jsx
+++ b/src/features/users/components/SpotListTab.jsx
@@ -84,13 +84,13 @@ export const SpotListTab = ({ userInfo }) => {
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
-        <Box width={{ xs: "90vw", sm: "70vw" }}>
+        <Box width={{ xs: "75vw", sm: "90vw" }}>
           {!spots && <Spinner />}
           <SpotCard spots={userPostedSpots()} text={"投稿"} />
         </Box>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
-        <Box width={"70vw"}>
+        <Box width={{ xs: "75vw", sm: "90vw" }}>
           {!spots && <Spinner />}
           <SpotCard spots={userLikedSpots()} text={"いいね"} />
           <Box display={"flex"} justifyContent={"center"} sx={{mt: 2}}>


### PR DESCRIPTION
## 概要
- レスポンシブ対応後、画面レイアウトが崩れている箇所が存在したので修正しました。

## 実施したこと
- [x] ヒーローページのスクロールボタンが文字と重なっていたので修正
- [x] ユーザー情報ページの右端に余白があったため修正
- [x] スマートフォンのヘッダーの高さを修正
- [x] スポット新規投稿ボタンの表記を変更
- [x] 動画を表示するモーダルの表示を修正
- [x] スポット詳細モーダルに閉じるボタンを追加
- [x] ログイン前にコメントを投稿できないように修正
- [x] スマートフォンでのコメント表示レイアウトを修正
- [x] スポット新規投稿画面の余白を追加
