### PR TITLE
SNSシェア機能の修正

### DIFF
--- a/src/components/Elements/Modals/SpotDetailModal.jsx
+++ b/src/components/Elements/Modals/SpotDetailModal.jsx
@@ -1,11 +1,14 @@
-import React, { useState } from 'react';
-import { Box, Button, Dialog, DialogContent, IconButton, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { Box, Button, Dialog, DialogContent, Typography } from '@mui/material';
 import { SpotDetail } from '../../../features/spots/components/SpotDetail';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { VideoModal } from './VideoModal';
+import { useSpotsContext } from '../../../contexts/SpotsContext';
 
-export default function SpotDetailModal({ spotId, open, setOpen }) {
+export default function SpotDetailModal({ open, setOpen }) {
   const navigate = useNavigate();
+  const { spots } = useSpotsContext();
+  const { spotId } = useParams();
   const [ videoModalOpen, setVideoModalOpen ] = useState(false);
   const [ selectedSpot, setSelectedSpot ] = useState();
 
@@ -17,6 +20,19 @@ export default function SpotDetailModal({ spotId, open, setOpen }) {
   const handleVideoClick = () => {
     setVideoModalOpen(true);
   };
+
+  useEffect(() => {
+    if (spotId) {
+      setOpen(true);
+    }
+  }, [spotId]);
+
+  useEffect(() => {
+    if (spots && spotId) {
+      const spot = spots.find(spot => parseInt(spot.id) === parseInt(spotId));
+      setSelectedSpot(spot);
+    }
+  }, [spotId, spots]);
 
   return (
     <div>

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -135,7 +135,12 @@ export default function SpotModal({open, setOpen, spot, setLatLng}) {
               >
                 投稿を確認する
               </Button>
-              <ShareButton url={`https://twitter.com/share?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} (※PC💻環境より閲覧してください)&text=${spot.body}を投稿したよ！🎉【BackHacker.】で見に行かない？🌎%0a%0a`} />
+              <ShareButton
+                url={spot.body && spot.body.trim() !== ''
+                ? `https://twitter.com/intent/tweet?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} &text=「${spot.body}」を投稿したよ！🎉 バーチャル旅行アプリ【BackHacker.】で見に行こう🌎%0a%0a`
+                : `https://twitter.com/intent/tweet?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} &text=バーチャル旅行アプリ【BackHacker.】でスポットを投稿したよ🎉 さっそく見に行ってみよう🌎%0a%0a`
+            
+              } />
             </Box>
 
 

--- a/src/components/Elements/Modals/SpotModal.jsx
+++ b/src/components/Elements/Modals/SpotModal.jsx
@@ -139,7 +139,6 @@ export default function SpotModal({open, setOpen, spot, setLatLng}) {
                 url={spot.body && spot.body.trim() !== ''
                 ? `https://twitter.com/intent/tweet?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} &text=「${spot.body}」を投稿したよ！🎉 バーチャル旅行アプリ【BackHacker.】で見に行こう🌎%0a%0a`
                 : `https://twitter.com/intent/tweet?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(spot.id)} &text=バーチャル旅行アプリ【BackHacker.】でスポットを投稿したよ🎉 さっそく見に行ってみよう🌎%0a%0a`
-            
               } />
             </Box>
 

--- a/src/components/Layout/IndexSpotLayout.jsx
+++ b/src/components/Layout/IndexSpotLayout.jsx
@@ -61,7 +61,7 @@ export const IndexSpotLayout = () => {
             handleMarkerClick={handleMarkerClick}
             clickedMarkerId={clickedMarkerId}
           />
-          <SpotDetailModal spotId={spotId} open={open} setOpen={setOpen} />
+          <SpotDetailModal open={open} setOpen={setOpen} />
           <FloatingButton text={"スポットを投稿"} onClick={handleButtonClick} />
           <MessageModal
             open={loginModalOpen}

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -20,7 +20,6 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
     if (spots) {
       const spot = spots.find(spot => parseInt(spot.id) === parseInt(spotId));
       setSelectedSpot(spot);
-      console.log(selectedSpot)
     }
   }, [spotId, spots, currentUser]);
 

--- a/src/features/spots/components/SpotDetail.jsx
+++ b/src/features/spots/components/SpotDetail.jsx
@@ -20,6 +20,7 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
     if (spots) {
       const spot = spots.find(spot => parseInt(spot.id) === parseInt(spotId));
       setSelectedSpot(spot);
+      console.log(selectedSpot)
     }
   }, [spotId, spots, currentUser]);
 
@@ -124,7 +125,13 @@ export const SpotDetail = ({ spotId, selectedSpot, setSelectedSpot, handleVideoC
                 selectedSpot={selectedSpot}
               />
             </Box>
-            <ShareButton sx={{mx: 2}} url={`https://twitter.com/share?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(selectedSpot.id)} (※PC💻環境より閲覧してください)&text=【BackHacker.】で${selectedSpot.name}を見に行かない？🌎%0a%0a`}  />
+            <ShareButton
+              sx={{mx: 2}}
+              url={selectedSpot.name && selectedSpot.name.trim() !== ''
+                ? `https://twitter.com/intent/tweet?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(selectedSpot.id)}&text=バーチャル旅行アプリ【BackHacker.】で「${selectedSpot.name}」に行ってみよう！🌎%0a%0a`
+                : `https://twitter.com/intent/tweet?url=${process.env.REACT_APP_PUBLIC_URL}spots/${parseInt(selectedSpot.id)}&text=バーチャル旅行アプリ【BackHacker.】で旅行気分を味わってみよう！🌎%0a%0a`
+              }
+            />
           </Box>
           <Box sx={{px: 2, mt: 2}}>
             <Typography >{selectedSpot.description}</Typography>


### PR DESCRIPTION
## 概要
- Xシェア時の不具合を修正しました。

## 実施したこと
- [x] スポット詳細にURLから直接アクセスした際に、スポット詳細モーダルが表示されるように修正
 
[動画(スポット詳細モーダル開)](https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/317880a2-5876-49ce-8c48-f7142a36be06)

- [x] XシェアのURLを修正
  - [x] Androidアプリに対応したURLに修正
  - [x] Xで表示される文章を修正
  - [x] スポット名が存在しない場合の文章を追加

| スポット名あり | スポット名なし |
| :---: | :---: |
| <img width="588" alt="画像(スポット名ありXシェア)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/f204bc15-fe9d-444b-9385-7fae8ec2082d"> | <img width="590" alt="画像(スポット名なしXシェア)" src="https://github.com/ITOmaSabai/BackHacker-frontend/assets/139302064/502f026b-988f-4cb8-aad1-ab5b91f52952"> |