### PR TITLE
ユーザー情報ページ遷移のバグ修正

### DIFF
--- a/src/components/Layout/ProfileLayout.jsx
+++ b/src/components/Layout/ProfileLayout.jsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { useSpotsContext } from "../../contexts/SpotsContext";
 import { UserProfile } from "../../features/users/components/UserProfile"
-import { useParams } from "react-router-dom";
 import { getUsers } from "../../features/users/api/getUsers";
 import { SpotListTab } from "../../features/users/components/SpotListTab";
+import { useFirebaseAuth } from "../../hooks/useFirebaseAuth";
 
-export const UserLayout = () => {
+export const ProfileLayout = () => {
   const { loadSpots } = useSpotsContext();
-  const { id } = useParams();
+  const { userId } = useFirebaseAuth();
   const [ userInfo, setUserInfo ] = useState();
 
   useEffect(() => {
@@ -19,8 +19,8 @@ export const UserLayout = () => {
       try {
         const users = await getUsers();
 
-        if (id) {
-          const selectedUser = users.find(user => parseInt(user.id) === parseInt(id))
+        if (userId) {
+          const selectedUser = users.find(user => parseInt(user.id) === parseInt(userId))
           setUserInfo(selectedUser);
         }
       } catch (error) {
@@ -28,7 +28,7 @@ export const UserLayout = () => {
       }
     }
     fetchData();
-  }, [id])
+  }, [userId])
 
   if (!userInfo) {
     return <div></div>;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -7,6 +7,7 @@ import { IndexLikedSpotLayout } from '../components/Layout/IndexLikedSpotLayout'
 import { HeroLayout } from '../components/Layout/HeroLayout';
 import { TermsOfService } from '../features/terms_of_services/components/TermsOfService';
 import { PrivacyPolicy } from '../features/privacy_policy/components/PrivacyPolicy';
+import { ProfileLayout } from '../components/Layout/ProfileLayout';
 
 export const AppRoutes = () => {
   return (
@@ -16,7 +17,7 @@ export const AppRoutes = () => {
         <Route path="/spots" element={<CreateSpotLayout />} />
         <Route path="/map" element={<IndexSpotLayout />} />
         <Route path="spots/:spotId" element={<IndexSpotLayout />} />
-        <Route path="/profile" element={<UserLayout />} />
+        <Route path="/profile" element={<ProfileLayout />} />
         <Route path="/users/:id" element={<UserLayout />} />
         <Route path="/users/:userId/likes" element={<IndexLikedSpotLayout />} />
         <Route path="/terms-of-service" element={<TermsOfService />} />


### PR DESCRIPTION
## 概要
- スポット詳細ページから、「マイページ」をクリックしてもプロフィールページに遷移しないバグがあったため、修正しました。
- スポット詳細から遷移するユーザー情報ページと、マイページを押して遷移するプロフィールページのパスが同じだったため、コンポーネントが再レンダリングされず、遷移しないバグが発生していました。
- `/profile`パスにアクセスした際に、追加した`ProfileLayout`に遷移するようにしました。

## 実施したこと
- [x] スポット詳細ページからプロフィール(`/profile`パス)にアクセスした際、ログイン中ユーザーの情報が表示されない不具合を修正
  - [x] `ProfileLayout`を追加
  - [x] マイページをクリックした際、`ProfileLayout`に遷移するように修正